### PR TITLE
as_root(): accept all KISS_SU values by default

### DIFF
--- a/kiss
+++ b/kiss
@@ -37,17 +37,8 @@ as_root() {
     [ "$uid" = 0 ] || log "Using '${su:=su}' (to become ${user:=root})"
 
     case ${su##*/} in
-        doas|sudo|ssu)
-            "$su" -u "$user" -- env "$@"
-        ;;
-
-        su)
-            "$su" -c "env $* <&3" "$user" 3<&0 </dev/tty
-        ;;
-
-        *)
-            die "Invalid KISS_SU value: ${su##*/} (valid: doas, sudo, ssu, su)"
-        ;;
+        su) "$su" -c "env $* <&3" "$user" 3<&0 </dev/tty ;;
+        *) "$su" -u "$user" -- env "$@" ;;
     esac
 }
 


### PR DESCRIPTION
This change ensures that niche tools that are not packaged in repositories
can be used without the need of it being implemented inside the package
manager itself. We don't support these tools, however most of them follow
a similar syntax as with 'sudo', and they can be run.

See: https://github.com/kiss-community/kiss/issues/12#issuecomment-799055508