### PR TITLE
kiss: make the install prompt only appear when extra dependencies

### DIFF
--- a/kiss
+++ b/kiss
@@ -584,6 +584,8 @@ pkg_build() {
 
     log "Resolving dependencies"
 
+    nexplicit="$#"
+
     # Mark packages passed on the command-line separately from those
     # detected as dependencies. We need to treat explicitly passed packages
     # differently from those pulled in as dependencies.
@@ -615,8 +617,8 @@ pkg_build() {
 
     log "Building: $*"
 
-    # Only ask for confirmation if more than one package needs to be built.
-    [ "$#" -gt 1 ] || [ "$pkg_update" ] && prompt
+    # Only ask for confirmation if dependencies need to be built.
+    [ "$#" -ne "$nexplicit" ] || [ "$pkg_update" ] && prompt
 
     for pkg do pkg_lint "$pkg"; done
 


### PR DESCRIPTION
The prompt used to appear when more than 1 packages were to be installed, but
this also happened when they all were specified on the commandline (even when
no extra dependencies were resolved). This is kind of redundant behaviour.

Now it will only appear when the number of packages explicitly supplied to
it and number of packages after dependency resolution are unequal (because
dependencies were found on resolution). I assume this was meant to be the
original intent for the behaviour but was left behind even after pkg_install()
gained the ability to receive multiple arguments.

Signed-off-by: FriendlyNeighborhoodShane <shane.880088.supw@gmail.com>