### PR TITLE
kiss-size: display correct size when KISS_ROOT is set

### DIFF
--- a/contrib/kiss-size
+++ b/contrib/kiss-size
@@ -27,7 +27,8 @@ kiss list "${1:-null}" >/dev/null || {
 
 # Filter directories from manifest and leave only files.
 # Directories in the manifest end in a trailing '/'.
-files=$(sed 's|.*/$||' "$KISS_ROOT/var/db/kiss/installed/$1/manifest")
+files=$(sed -e "s|^|$KISS_ROOT|" -e "s|.*/$||" \
+        "$KISS_ROOT/var/db/kiss/installed/$1/manifest")
 
 # Send the file list to 'du'.
 # This unquoted variable is safe as word splitting is intended


### PR DESCRIPTION
`kiss-size` fetches the manifest file from the correct path, but the file list passed to `du` does not have `KISS_ROOT` appended to each filename, resulting in misleading output (will show 0KB if package is present in `KISS_ROOT` but not on host) as the size is fetched from the host in all cases.