### PR TITLE
Don't build make depends if the package is already built

### DIFF
--- a/kiss
+++ b/kiss
@@ -369,8 +369,8 @@ pkg_depends() {
         [ "$3" ] && [ -z "$2" ] && (pkg_list "$1" >/dev/null) && return
 
         # Recurse through the dependencies of the child packages.
-        while read -r dep _ || [ "$dep" ]; do
-            [ "${dep##\#*}" ] && pkg_depends "$dep" '' "$3"
+        while read -r dep make || [ "$dep" ]; do
+            { [ "make" != "$make" ] || ! pkg_cache "$1"; } && [ "${dep##\#*}" ] && pkg_depends "$dep" '' "$3"
         done 2>/dev/null < "$(pkg_find "$1")/depends" ||:
 
         # After child dependencies are added to the list,


### PR DESCRIPTION
If we are attempting to install/build a package and that package is
already built, we don't need to consider any make depends of said
package.

Closes #29

I'm aware that the dependency management of kiss may be redone in the near future.

Also I quote "make" below to silence shellcheck since I think it thinks I may be trying to incorrectly invoke the command.