### PR TITLE
Don't save decompressed tar archive to disk

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 |/
-|\ISS                                                           https://k1ss.org
+|\ISS                                                      https://k1sslinux.org
 ________________________________________________________________________________
 
 
@@ -8,5 +8,5 @@ ________________________________________________________________________________
 
 KISS' tiny package manager.
 
-Documentation: https://k1ss.org/package-manager
-               https://k1ss.org/package-system
+Documentation: https://k1sslinux.org/package-manager
+               https://k1sslinux.org/package-system

--- a/contrib/kiss-size
+++ b/contrib/kiss-size
@@ -27,7 +27,8 @@ kiss list "${1:-null}" >/dev/null || {
 
 # Filter directories from manifest and leave only files.
 # Directories in the manifest end in a trailing '/'.
-files=$(sed 's|.*/$||' "$KISS_ROOT/var/db/kiss/installed/$1/manifest")
+files=$(sed -e "s|^|$KISS_ROOT|" -e "s|.*/$||" \
+        "$KISS_ROOT/var/db/kiss/installed/$1/manifest")
 
 # Send the file list to 'du'.
 # This unquoted variable is safe as word splitting is intended

--- a/kiss
+++ b/kiss
@@ -463,7 +463,7 @@ pkg_fix_deps() {
         # fullpath of a library when using readelf. Best use we have here is
         # saving it in a buffer, so we don't use the dynamic loader everytime we
         # need to reference it.
-        lddbuf=$(ldd -- "$file" 2>/dev/null)
+        lddbuf=$(ldd -- "$file" 2>/dev/null) ||:
 
         case $elf_cmd in
             *readelf)

--- a/kiss
+++ b/kiss
@@ -1538,7 +1538,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.2.4\n' ;;
+        v|version)  printf '5.2.6\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'

--- a/kiss
+++ b/kiss
@@ -745,12 +745,8 @@ pkg_build() {
 
     if [ "$pkg_update" ]; then
         return
-
-    elif [ "$#" -gt 1 ] && prompt "Install built packages? [$*]"; then
-        args i "$@"
-
-    else
-        log "Run 'kiss i $*' to install the package(s)"
+    else 
+        prompt "Install built packages? [$*]" && args i "$@"
     fi
 }
 

--- a/kiss
+++ b/kiss
@@ -1546,7 +1546,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.2.7\n' ;;
+        v|version)  printf '5.2.8\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'

--- a/kiss
+++ b/kiss
@@ -91,7 +91,7 @@ decompress() {
         *.lz)       lzip -dc  ;;
         *.tar)      cat       ;;
         *.tgz|*.gz) gzip -d   ;;
-        *.xz|*.txz) xz -dcT 0 ;;
+        *.xz|*.txz) xz -dcT0  ;;
         *.zst)      zstd -dc  ;;
     esac < "$1"
 }
@@ -571,7 +571,7 @@ pkg_tar() (
         gz)   gzip -6  ;;
         lzma) lzma -z  ;;
         lz)   lzip -z  ;;
-        xz)   xz -zT 0 ;;
+        xz)   xz -zT0  ;;
         zst)  zstd -z  ;;
     esac > "$bin_dir/$1@$version-$release.tar.${KISS_COMPRESS:=gz}"
 

--- a/kiss
+++ b/kiss
@@ -1372,8 +1372,8 @@ pkg_updates() {
     set +f --
 
     for pkg in "$sys_db/"*; do
-        read -r db_ver db_rel < "$pkg/version"
-        read -r re_ver re_rel < "$(pkg_find "${pkg##*/}")/version"
+        read -r db_ver db_rel < "$pkg/version" || exit 1
+        read -r re_ver re_rel < "$(pkg_find "${pkg##*/}")/version" || exit 1
 
         # Compare installed packages to repository packages.
         [ "$db_ver-$db_rel" = "$re_ver-$re_rel" ] || {

--- a/kiss
+++ b/kiss
@@ -1544,7 +1544,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.2.6\n' ;;
+        v|version)  printf '5.2.7\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'

--- a/kiss
+++ b/kiss
@@ -687,7 +687,7 @@ pkg_build() {
         run_hook pre-build "$pkg" "$pkg_dir/$pkg"
 
         # Call the build script, log the output to the terminal and to a file.
-        # There's no PIPEFAIL in POSIX shelll so we must resort to tricks like
+        # There's no PIPEFAIL in POSIX shell so we must resort to tricks like
         # killing the script ourselves.
         { "$repo_dir/build" "$pkg_dir/$pkg" "$build_version" 2>&1 || {
             log "$pkg" "Build failed"
@@ -714,7 +714,7 @@ pkg_build() {
         find "$pkg_dir/$pkg/usr/lib" -name \*.la -exec rm -f {} + 2>/dev/null ||:
 
         # Remove this unneeded file from all packages as it is an endless
-        # source of conflicts. This is used with info pages we we do not support.
+        # source of conflicts. This is used with info pages which we do not support.
         rm -f "$pkg_dir/$pkg/usr/lib/charset.alias"
 
         # Create the manifest file early and make it empty. This ensures that
@@ -1661,7 +1661,7 @@ main() {
     )"} || elf_cmd=ldd
 
     # Store the date and time of script invocation to be used as the name of
-    # the log files the package manager creates uring builds.
+    # the log files the package manager creates during builds.
     time=$(date +%Y-%m-%d-%H:%M)
 
     # Make note of the user's current ID to do root checks later on.

--- a/kiss
+++ b/kiss
@@ -1569,7 +1569,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.2.8\n' ;;
+        v|version)  printf '5.3.0\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'

--- a/kiss
+++ b/kiss
@@ -647,14 +647,17 @@ pkg_build() {
     # Install any pre-built dependencies if they exist in the binary
     # directory and are up to date.
     for pkg do
-        ! contains "$explicit_build" "$pkg" && pkg_cache "$pkg" && {
+        if ! contains "$explicit_build" "$pkg" && pkg_cache "$pkg"; then
             log "$pkg" "Found pre-built binary, installing"
             (KISS_FORCE=1 args i "$tar_file")
-
-            # Remove the now installed package from the build list.
-            shift
-        }
+        else
+            remaining_pkgs=" $remaining_pkgs $pkg"
+        fi
     done
+
+    # See [1] at top of script.
+    # shellcheck disable=2046,2086
+    set -- $remaining_pkgs
 
     for pkg do pkg_sources "$pkg"; done
     pkg_verify "$@"

--- a/kiss
+++ b/kiss
@@ -616,7 +616,7 @@ pkg_build() {
     log "Building: $*"
 
     # Only ask for confirmation if more than one package needs to be built.
-    [ "$#" -gt 1 ] || [ "$pkg_update" ] && { prompt || exit 0 ;}
+    [ "$#" -gt 1 ] || [ "$pkg_update" ] && prompt
 
     for pkg do pkg_lint "$pkg"; done
 
@@ -1136,7 +1136,8 @@ pkg_remove() {
 
     # Reset 'trap' to its original value. Removal is done so
     # we no longer need to block 'Ctrl+C'.
-    trap pkg_clean EXIT INT
+    trap pkg_clean EXIT
+    trap 'pkg_clean; exit 1' INT
 
     log "$1" "Removed successfully"
 }
@@ -1260,7 +1261,8 @@ pkg_install() {
 
     # Reset 'trap' to its original value. Installation is done so we no longer
     # need to block 'Ctrl+C'.
-    trap pkg_clean EXIT INT
+    trap pkg_clean EXIT
+    trap 'pkg_clean; exit 1' INT
 
     if [ -x "$sys_db/$pkg_name/post-install" ]; then
         log "$pkg_name" "Running post-install hook"
@@ -1372,8 +1374,8 @@ pkg_updates() {
     set +f --
 
     for pkg in "$sys_db/"*; do
-        read -r db_ver db_rel < "$pkg/version" || exit 1
-        read -r re_ver re_rel < "$(pkg_find "${pkg##*/}")/version" || exit 1
+        read -r db_ver db_rel < "$pkg/version"
+        read -r re_ver re_rel < "$(pkg_find "${pkg##*/}")/version"
 
         # Compare installed packages to repository packages.
         [ "$db_ver-$db_rel" = "$re_ver-$re_rel" ] || {
@@ -1388,7 +1390,7 @@ pkg_updates() {
         log "Detected package manager update"
         log "The package manager will be updated first"
 
-        prompt || exit 0
+        prompt
 
         pkg_build kiss
         args i kiss
@@ -1619,7 +1621,8 @@ main() {
 
     # Catch errors and ensure that build files and directories are cleaned
     # up before we die. This occurs on 'Ctrl+C' as well as success and error.
-    trap pkg_clean EXIT INT
+    trap pkg_clean EXIT
+    trap 'pkg_clean; exit 1' INT
 
     # Figure out which 'sudo' command to use based on the user's choice or what
     # is available on the system.

--- a/kiss
+++ b/kiss
@@ -435,6 +435,14 @@ pkg_strip() {
     done 2>/dev/null ||:
 }
 
+pkg_fix_deps_fullpath() {
+    # Return the canonical path of libraries extracted by readelf.
+    while read -r dep _ rslv _; do
+        [ "$dep" = "$1" ] || continue
+        printf '%s\n' "$rslv"
+    done
+}
+
 pkg_fix_deps() {
     # Dynamically look for missing runtime dependencies by checking each
     # binary and library with 'ldd'. This catches any extra libraries and or
@@ -451,13 +459,19 @@ pkg_fix_deps() {
     find "$pkg_dir/${PWD##*/}/" -type f 2>/dev/null |
 
     while read -r file; do
+        # We call ldd regardless here, because we also use it to retrieve the
+        # fullpath of a library when using readelf. Best use we have here is
+        # saving it in a buffer, so we don't use the dynamic loader everytime we
+        # need to reference it.
+        lddbuf=$(ldd -- "$file" 2>/dev/null)
+
         case $elf_cmd in
             *readelf)
                 "$elf_cmd" -d "$file"
             ;;
 
             *)
-                ldd -- "$file"
+                printf '%s\n' "$lddbuf"
             ;;
         esac 2>/dev/null |
 
@@ -467,6 +481,12 @@ pkg_fix_deps() {
                     # readelf: 0x0000 (NEEDED) Shared library: [libjson-c.so.5]
                     line=${line##*\[}
                     line=${line%%\]*}
+
+                    # Retrieve the fullpath of the library from our ldd buffer.
+                    case $elf_cmd in
+                        *readelf) line=$(printf '%s\n' "$lddbuf" |
+                                         pkg_fix_deps_fullpath "$line")
+                    esac
 
                     # ldd:     libjson-c.so.5 => /lib/libjson-c.so.5 ...
                     line=${line##*=> }

--- a/kiss
+++ b/kiss
@@ -1565,7 +1565,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.3.0\n' ;;
+        v|version)  printf '5.3.1\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'

--- a/kiss
+++ b/kiss
@@ -584,6 +584,8 @@ pkg_build() {
 
     log "Resolving dependencies"
 
+    nexplicit="$#"
+
     # Mark packages passed on the command-line separately from those
     # detected as dependencies. We need to treat explicitly passed packages
     # differently from those pulled in as dependencies.
@@ -615,8 +617,8 @@ pkg_build() {
 
     log "Building: $*"
 
-    # Only ask for confirmation if more than one package needs to be built.
-    [ "$#" -gt 1 ] || [ "$pkg_update" ] && prompt
+    # Only ask for confirmation if dependencies need to be built.
+    [ "$#" -ne "$nexplicit" ] || [ "$pkg_update" ] && prompt
 
     for pkg do pkg_lint "$pkg"; done
 

--- a/kiss
+++ b/kiss
@@ -637,10 +637,14 @@ pkg_build() {
     for pkg do pkg_sources "$pkg"; done
     pkg_verify "$@"
 
+    # Record the total number of packages under a variable so that they are
+    # accessible to hooks.
+    pkg_total=$#
+
     # Finally build and create tarballs for all passed packages and
     # dependencies.
     for pkg do
-        log "$pkg" "Building package ($((in+=1))/$#)"
+        log "$pkg" "Building package ($((pkg_cur+=1))/$pkg_total)"
 
         run_hook pre-extract "$pkg" "$pkg_dir/$pkg"
         pkg_extract "$pkg"

--- a/kiss
+++ b/kiss
@@ -37,17 +37,8 @@ as_root() {
     [ "$uid" = 0 ] || log "Using '${su:=su}' (to become ${user:=root})"
 
     case ${su##*/} in
-        doas|sudo|ssu)
-            "$su" -u "$user" -- env "$@"
-        ;;
-
-        su)
-            "$su" -c "env $* <&3" "$user" 3<&0 </dev/tty
-        ;;
-
-        *)
-            die "Invalid KISS_SU value: ${su##*/} (valid: doas, sudo, ssu, su)"
-        ;;
+        su) "$su" -c "env $* <&3" "$user" 3<&0 </dev/tty ;;
+        *) "$su" -u "$user" -- env "$@" ;;
     esac
 }
 

--- a/kiss
+++ b/kiss
@@ -465,8 +465,8 @@ pkg_fix_deps() {
             case $line in
                 *NEEDED*\[*\] | *'=>'*)
                     # readelf: 0x0000 (NEEDED) Shared library: [libjson-c.so.5]
-                    line=${line##*[}
-                    line=${line%%]*}
+                    line=${line##*\[}
+                    line=${line%%\]*}
 
                     # ldd:     libjson-c.so.5 => /lib/libjson-c.so.5 ...
                     line=${line##*=> }

--- a/kiss
+++ b/kiss
@@ -1304,7 +1304,7 @@ pkg_updates() {
     for repo do
         # Go to the root of the repository (if it exists).
         if ! cd "$repo" 2>/dev/null; then
-            log "Skipping "$repo", not a directory"; continue
+            log "Skipping $repo, not a directory"; continue
         fi
 
         case $(git remote 2>/dev/null) in

--- a/kiss
+++ b/kiss
@@ -2,7 +2,7 @@
 # shellcheck source=/dev/null
 #
 # This is a simple package manager written in POSIX shell for use
-# in KISS Linux (https://k1ss.org).
+# in KISS Linux (https://k1sslinux.org).
 #
 # Created by Dylan Araps.
 

--- a/kiss
+++ b/kiss
@@ -1123,7 +1123,7 @@ pkg_remove() {
     [ "$KISS_FORCE" = 1 ] || {
         log "$1" "Checking for reverse dependencies"
 
-        (cd "$sys_db"; set +f; grep -lFx "$1" -- */depends) &&
+        (cd "$sys_db"; set +f; grep -lFx -- "$1" */depends) &&
             die "$1" "Can't remove package, others depend on it"
     }
 

--- a/kiss
+++ b/kiss
@@ -37,7 +37,7 @@ as_root() {
     [ "$uid" = 0 ] || log "Using '${su:=su}' (to become ${user:=root})"
 
     case ${su##*/} in
-        doas|sudo|sls)
+        doas|sudo|ssu)
             "$su" -u "$user" -- env "$@"
         ;;
 
@@ -46,7 +46,7 @@ as_root() {
         ;;
 
         *)
-            die "Invalid KISS_SU value: $su (valid: doas, sudo, sls, su)"
+            die "Invalid KISS_SU value: ${su##*/} (valid: doas, sudo, ssu, su)"
         ;;
     esac
 }
@@ -1360,7 +1360,7 @@ pkg_updates() {
                             # on the other hand requires that each argument be
                             # properly quoted as the command passed to it must
                             # be a string... This sets quotes where needed.
-                            case $su in *su) git_cmd="'$git_cmd'"; esac
+                            case ${su##*/} in su) git_cmd="'$git_cmd'"; esac
 
                             # Spawn a subshell to run multiple commands as
                             # root at once. This makes things easier on users
@@ -1635,7 +1635,7 @@ main() {
 
     # Figure out which 'sudo' command to use based on the user's choice or what
     # is available on the system.
-    su=${KISS_SU:-"$(command -v sudo || command -v doas || command -v sls)"} ||:
+    su=${KISS_SU:-"$(command -v sudo || command -v doas || command -v ssu)"} ||:
 
     # Figure out which utility is available to dump elf information.
     elf_cmd=${KISS_ELF:="$(

--- a/kiss
+++ b/kiss
@@ -1637,7 +1637,7 @@ main() {
 
     # Figure out which 'sudo' command to use based on the user's choice or what
     # is available on the system.
-    su=${KISS_SU:-"$(command -v sudo || command -v doas || command -v ssu)"} ||:
+    su=${KISS_SU:-"$(command -v sudo || command -v doas || command -v ssu)"} || su=su
 
     # Figure out which utility is available to dump elf information.
     elf_cmd=${KISS_ELF:="$(

--- a/kiss
+++ b/kiss
@@ -625,7 +625,7 @@ pkg_build() {
     log "Building: $*"
 
     # Only ask for confirmation if more than one package needs to be built.
-    [ "$#" -gt 1 ] || [ "$pkg_update" ] && prompt
+    [ "$#" -gt 1 ] || [ "$pkg_update" ] && { prompt || exit 0 ;}
 
     for pkg do pkg_lint "$pkg"; done
 
@@ -1400,7 +1400,7 @@ pkg_updates() {
         log "Detected package manager update"
         log "The package manager will be updated first"
 
-        prompt
+        prompt || exit 0
 
         pkg_build kiss
         args i kiss

--- a/kiss
+++ b/kiss
@@ -1374,11 +1374,6 @@ pkg_updates() {
                 }
             ;;
         esac
-
-        [ ! -x update ] || {
-            log "$PWD" "Running update hook"
-            ./update
-        }
     done
 
     log "Checking for new package versions"

--- a/kiss
+++ b/kiss
@@ -1304,7 +1304,9 @@ pkg_updates() {
     # Update each repository in '$KISS_PATH'.
     for repo do
         # Go to the root of the repository (if it exists).
-        cd "$repo"
+        if ! cd "$repo" 2>/dev/null; then
+            log "Skipping "$repo", not a directory"; continue
+        fi
 
         case $(git remote 2>/dev/null) in
             "")

--- a/kiss
+++ b/kiss
@@ -1616,7 +1616,7 @@ main() {
 
     # Allow the user to disable colors in output via an environment variable.
     # Check this once so as to not slow down printing.
-    [ "$KISS_COLOR" = 0 ] || lcol='\033[1;33m' lcol2='\033[1;34m' lclr='\033[m'
+    [ "$KISS_COLOR" = 0 ] || ! [ -t 1 ] || lcol='\033[1;33m' lcol2='\033[1;34m' lclr='\033[m'
 
     # Store the original working directory to ensure that relative paths
     # passed by the user on the command-line properly resolve to locations

--- a/kiss
+++ b/kiss
@@ -1547,7 +1547,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.2.3\n' ;;
+        v|version)  printf '5.2.4\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'

--- a/kiss
+++ b/kiss
@@ -279,15 +279,12 @@ pkg_extract() {
             # GNU tar's '--strip-components 1'.
             *://*.tar|*://*.tar.??|*://*.tar.???|*://*.tar.????|*://*.t?z)
                 # Decompress the archive to a temporary .tar archive.
-                decompress "$src_dir/$1/${dest:-.}/${src##*/}" > .ktar
-
-                # Extract the tar archive to the current directory.
-                tar xf .ktar || die "$1" "Couldn't extract ${src##*/}"
+                decompress "$src_dir/$1/${dest:-.}/${src##*/}" | tar xf - || die "$1" "Couldn't extract ${src##*/}"
 
                 # Iterate over all directories in the first level of the
                 # tarball's manifest. This is our equivalent of GNU tar's
                 # '--strip-components 1'.
-                tar tf .ktar | while IFS=/ read -r dir _; do
+                decompress "$src_dir/$1/${dest:-.}/${src##*/}" | tar tf - | cut -d"/" -f1 | while read -r dir ; do
                     # Some tarballs contain './' as the top-level directory,
                     # we need to skip these occurances.
                     [ -d "${dir#.}" ] || continue
@@ -320,10 +317,6 @@ pkg_extract() {
                     # as we may leave files in here due to above.
                     rm -rf "$pid-$dir"
                 done
-
-                # Clean up after ourselves and remove the temporary tar
-                # archive we've created. Not needed at all really.
-                rm -f .ktar
             ;;
 
             # Zip archives.

--- a/kiss
+++ b/kiss
@@ -219,10 +219,17 @@ pkg_sources() {
             log "$1" "Downloading $src"
             mkdir -p "$PWD/$dest"
 
+            # We don't want interrupt to exit immediately here, so we change the
+            # behaviour here.
+            trap pkg_clean INT
+
             curl "$src" -fLo "./${dest:-.}/${src##*/}" || {
                 rm -f "./${dest:-.}/${src##*/}"
                 die "$1" "Failed to download $src"
             }
+
+            # Restore the trap to the original value.
+            trap 'pkg_clean; exit 1' INT
 
         # Local source (relative).
         elif [ -e "$repo_dir/$src" ]; then

--- a/kiss
+++ b/kiss
@@ -1572,7 +1572,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.3.1\n' ;;
+        v|version)  printf '5.3.2\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'


### PR DESCRIPTION
The extraction phase could take up to twice as much space as needed.
This was due to saving a decompressed tar and then extracting it. Now
we don't save the decompressed tar and decompress and extract together.