### PR TITLE
kiss: use blake3 for checksums

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 |/
-|\ISS                                                           https://k1ss.org
+|\ISS                                                      https://k1sslinux.org
 ________________________________________________________________________________
 
 
@@ -8,5 +8,5 @@ ________________________________________________________________________________
 
 KISS' tiny package manager.
 
-Documentation: https://k1ss.org/package-manager
-               https://k1ss.org/package-system
+Documentation: https://k1sslinux.org/package-manager
+               https://k1sslinux.org/package-system

--- a/contrib/kiss-repo-orphans
+++ b/contrib/kiss-repo-orphans
@@ -3,7 +3,7 @@
 
 cd "$KISS_ROOT/var/db/kiss/installed"
 
-kiss s * | while read -r path; do
+kiss s ./* | while IFS=/ read -r _ path; do
     pkg=${path##*/}
 
     case $seen in *" $pkg "*)

--- a/contrib/kiss-repo-orphans
+++ b/contrib/kiss-repo-orphans
@@ -3,15 +3,18 @@
 
 cd "$KISS_ROOT/var/db/kiss/installed"
 
-for pkg in *; do
-    i=1
+kiss s * | while read -r path; do
+    pkg=${path##*/}
 
-    kiss s "$pkg" | while read -r line; do
-        case $i-$line in ("1-$PWD/$pkg")
-            printf '%s\n' "$pkg"
-            continue
-        esac
+    case $seen in *" $pkg "*)
+        continue
+    esac
 
-        i=$((i + 1))
-    done
+    case $path in "$PWD/$pkg")
+        printf '%s\n' "$pkg"
+    esac
+
+    seen="$seen $pkg "
 done
+
+

--- a/contrib/kiss-repo-orphans
+++ b/contrib/kiss-repo-orphans
@@ -1,0 +1,17 @@
+#!/bin/sh -e
+# List packages which aren't present in any repository.
+
+cd "$KISS_ROOT/var/db/kiss/installed"
+
+for pkg in *; do
+    i=1
+
+    kiss s "$pkg" | while read -r line; do
+        case $i-$line in ("1-$PWD/$pkg")
+            printf '%s\n' "$pkg"
+            continue
+        esac
+
+        i=$((i + 1))
+    done
+done

--- a/contrib/kiss-size
+++ b/contrib/kiss-size
@@ -27,7 +27,8 @@ kiss list "${1:-null}" >/dev/null || {
 
 # Filter directories from manifest and leave only files.
 # Directories in the manifest end in a trailing '/'.
-files=$(sed 's|.*/$||' "$KISS_ROOT/var/db/kiss/installed/$1/manifest")
+files=$(sed -e "s|^|$KISS_ROOT|" -e "s|.*/$||" \
+        "$KISS_ROOT/var/db/kiss/installed/$1/manifest")
 
 # Send the file list to 'du'.
 # This unquoted variable is safe as word splitting is intended

--- a/kiss
+++ b/kiss
@@ -463,7 +463,7 @@ pkg_fix_deps() {
         # fullpath of a library when using readelf. Best use we have here is
         # saving it in a buffer, so we don't use the dynamic loader everytime we
         # need to reference it.
-        lddbuf=$(ldd -- "$file" 2>/dev/null)
+        lddbuf=$(ldd -- "$file" 2>/dev/null) ||:
 
         case $elf_cmd in
             *readelf)

--- a/kiss
+++ b/kiss
@@ -1538,7 +1538,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.2.4\n' ;;
+        v|version)  printf '5.2.6\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'

--- a/kiss
+++ b/kiss
@@ -745,12 +745,8 @@ pkg_build() {
 
     if [ "$pkg_update" ]; then
         return
-
-    elif [ "$#" -gt 1 ] && prompt "Install built packages? [$*]"; then
-        args i "$@"
-
-    else
-        log "Run 'kiss i $*' to install the package(s)"
+    else 
+        prompt "Install built packages? [$*]" && args i "$@"
     fi
 }
 

--- a/kiss
+++ b/kiss
@@ -1546,7 +1546,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.2.7\n' ;;
+        v|version)  printf '5.2.8\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'

--- a/kiss
+++ b/kiss
@@ -91,7 +91,7 @@ decompress() {
         *.lz)       lzip -dc  ;;
         *.tar)      cat       ;;
         *.tgz|*.gz) gzip -d   ;;
-        *.xz|*.txz) xz -dcT 0 ;;
+        *.xz|*.txz) xz -dcT0  ;;
         *.zst)      zstd -dc  ;;
     esac < "$1"
 }
@@ -571,7 +571,7 @@ pkg_tar() (
         gz)   gzip -6  ;;
         lzma) lzma -z  ;;
         lz)   lzip -z  ;;
-        xz)   xz -zT 0 ;;
+        xz)   xz -zT0  ;;
         zst)  zstd -z  ;;
     esac > "$bin_dir/$1@$version-$release.tar.${KISS_COMPRESS:=gz}"
 

--- a/kiss
+++ b/kiss
@@ -1372,8 +1372,8 @@ pkg_updates() {
     set +f --
 
     for pkg in "$sys_db/"*; do
-        read -r db_ver db_rel < "$pkg/version"
-        read -r re_ver re_rel < "$(pkg_find "${pkg##*/}")/version"
+        read -r db_ver db_rel < "$pkg/version" || exit 1
+        read -r re_ver re_rel < "$(pkg_find "${pkg##*/}")/version" || exit 1
 
         # Compare installed packages to repository packages.
         [ "$db_ver-$db_rel" = "$re_ver-$re_rel" ] || {

--- a/kiss
+++ b/kiss
@@ -1544,7 +1544,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.2.6\n' ;;
+        v|version)  printf '5.2.7\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'

--- a/kiss
+++ b/kiss
@@ -687,7 +687,7 @@ pkg_build() {
         run_hook pre-build "$pkg" "$pkg_dir/$pkg"
 
         # Call the build script, log the output to the terminal and to a file.
-        # There's no PIPEFAIL in POSIX shelll so we must resort to tricks like
+        # There's no PIPEFAIL in POSIX shell so we must resort to tricks like
         # killing the script ourselves.
         { "$repo_dir/build" "$pkg_dir/$pkg" "$build_version" 2>&1 || {
             log "$pkg" "Build failed"
@@ -714,7 +714,7 @@ pkg_build() {
         find "$pkg_dir/$pkg/usr/lib" -name \*.la -exec rm -f {} + 2>/dev/null ||:
 
         # Remove this unneeded file from all packages as it is an endless
-        # source of conflicts. This is used with info pages we we do not support.
+        # source of conflicts. This is used with info pages which we do not support.
         rm -f "$pkg_dir/$pkg/usr/lib/charset.alias"
 
         # Create the manifest file early and make it empty. This ensures that
@@ -1661,7 +1661,7 @@ main() {
     )"} || elf_cmd=ldd
 
     # Store the date and time of script invocation to be used as the name of
-    # the log files the package manager creates uring builds.
+    # the log files the package manager creates during builds.
     time=$(date +%Y-%m-%d-%H:%M)
 
     # Make note of the user's current ID to do root checks later on.

--- a/kiss
+++ b/kiss
@@ -1569,7 +1569,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.2.8\n' ;;
+        v|version)  printf '5.3.0\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'

--- a/kiss
+++ b/kiss
@@ -647,14 +647,17 @@ pkg_build() {
     # Install any pre-built dependencies if they exist in the binary
     # directory and are up to date.
     for pkg do
-        ! contains "$explicit_build" "$pkg" && pkg_cache "$pkg" && {
+        if ! contains "$explicit_build" "$pkg" && pkg_cache "$pkg"; then
             log "$pkg" "Found pre-built binary, installing"
             (KISS_FORCE=1 args i "$tar_file")
-
-            # Remove the now installed package from the build list.
-            shift
-        }
+        else
+            remaining_pkgs=" $remaining_pkgs $pkg"
+        fi
     done
+
+    # See [1] at top of script.
+    # shellcheck disable=2046,2086
+    set -- $remaining_pkgs
 
     for pkg do pkg_sources "$pkg"; done
     pkg_verify "$@"

--- a/kiss
+++ b/kiss
@@ -616,7 +616,7 @@ pkg_build() {
     log "Building: $*"
 
     # Only ask for confirmation if more than one package needs to be built.
-    [ "$#" -gt 1 ] || [ "$pkg_update" ] && { prompt || exit 0 ;}
+    [ "$#" -gt 1 ] || [ "$pkg_update" ] && prompt
 
     for pkg do pkg_lint "$pkg"; done
 
@@ -1136,7 +1136,8 @@ pkg_remove() {
 
     # Reset 'trap' to its original value. Removal is done so
     # we no longer need to block 'Ctrl+C'.
-    trap pkg_clean EXIT INT
+    trap pkg_clean EXIT
+    trap 'pkg_clean; exit 1' INT
 
     log "$1" "Removed successfully"
 }
@@ -1260,7 +1261,8 @@ pkg_install() {
 
     # Reset 'trap' to its original value. Installation is done so we no longer
     # need to block 'Ctrl+C'.
-    trap pkg_clean EXIT INT
+    trap pkg_clean EXIT
+    trap 'pkg_clean; exit 1' INT
 
     if [ -x "$sys_db/$pkg_name/post-install" ]; then
         log "$pkg_name" "Running post-install hook"
@@ -1372,8 +1374,8 @@ pkg_updates() {
     set +f --
 
     for pkg in "$sys_db/"*; do
-        read -r db_ver db_rel < "$pkg/version" || exit 1
-        read -r re_ver re_rel < "$(pkg_find "${pkg##*/}")/version" || exit 1
+        read -r db_ver db_rel < "$pkg/version"
+        read -r re_ver re_rel < "$(pkg_find "${pkg##*/}")/version"
 
         # Compare installed packages to repository packages.
         [ "$db_ver-$db_rel" = "$re_ver-$re_rel" ] || {
@@ -1388,7 +1390,7 @@ pkg_updates() {
         log "Detected package manager update"
         log "The package manager will be updated first"
 
-        prompt || exit 0
+        prompt
 
         pkg_build kiss
         args i kiss
@@ -1619,7 +1621,8 @@ main() {
 
     # Catch errors and ensure that build files and directories are cleaned
     # up before we die. This occurs on 'Ctrl+C' as well as success and error.
-    trap pkg_clean EXIT INT
+    trap pkg_clean EXIT
+    trap 'pkg_clean; exit 1' INT
 
     # Figure out which 'sudo' command to use based on the user's choice or what
     # is available on the system.

--- a/kiss
+++ b/kiss
@@ -435,6 +435,14 @@ pkg_strip() {
     done 2>/dev/null ||:
 }
 
+pkg_fix_deps_fullpath() {
+    # Return the canonical path of libraries extracted by readelf.
+    while read -r dep _ rslv _; do
+        [ "$dep" = "$1" ] || continue
+        printf '%s\n' "$rslv"
+    done
+}
+
 pkg_fix_deps() {
     # Dynamically look for missing runtime dependencies by checking each
     # binary and library with 'ldd'. This catches any extra libraries and or
@@ -451,13 +459,19 @@ pkg_fix_deps() {
     find "$pkg_dir/${PWD##*/}/" -type f 2>/dev/null |
 
     while read -r file; do
+        # We call ldd regardless here, because we also use it to retrieve the
+        # fullpath of a library when using readelf. Best use we have here is
+        # saving it in a buffer, so we don't use the dynamic loader everytime we
+        # need to reference it.
+        lddbuf=$(ldd -- "$file" 2>/dev/null)
+
         case $elf_cmd in
             *readelf)
                 "$elf_cmd" -d "$file"
             ;;
 
             *)
-                ldd -- "$file"
+                printf '%s\n' "$lddbuf"
             ;;
         esac 2>/dev/null |
 
@@ -467,6 +481,12 @@ pkg_fix_deps() {
                     # readelf: 0x0000 (NEEDED) Shared library: [libjson-c.so.5]
                     line=${line##*\[}
                     line=${line%%\]*}
+
+                    # Retrieve the fullpath of the library from our ldd buffer.
+                    case $elf_cmd in
+                        *readelf) line=$(printf '%s\n' "$lddbuf" |
+                                         pkg_fix_deps_fullpath "$line")
+                    esac
 
                     # ldd:     libjson-c.so.5 => /lib/libjson-c.so.5 ...
                     line=${line##*=> }

--- a/kiss
+++ b/kiss
@@ -1565,7 +1565,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.3.0\n' ;;
+        v|version)  printf '5.3.1\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'

--- a/kiss
+++ b/kiss
@@ -584,6 +584,8 @@ pkg_build() {
 
     log "Resolving dependencies"
 
+    nexplicit="$#"
+
     # Mark packages passed on the command-line separately from those
     # detected as dependencies. We need to treat explicitly passed packages
     # differently from those pulled in as dependencies.
@@ -615,8 +617,8 @@ pkg_build() {
 
     log "Building: $*"
 
-    # Only ask for confirmation if more than one package needs to be built.
-    [ "$#" -gt 1 ] || [ "$pkg_update" ] && prompt
+    # Only ask for confirmation if dependencies need to be built.
+    [ "$#" -ne "$nexplicit" ] || [ "$pkg_update" ] && prompt
 
     for pkg do pkg_lint "$pkg"; done
 

--- a/kiss
+++ b/kiss
@@ -637,10 +637,14 @@ pkg_build() {
     for pkg do pkg_sources "$pkg"; done
     pkg_verify "$@"
 
+    # Record the total number of packages under a variable so that they are
+    # accessible to hooks.
+    pkg_total=$#
+
     # Finally build and create tarballs for all passed packages and
     # dependencies.
     for pkg do
-        log "$pkg" "Building package ($((in+=1))/$#)"
+        log "$pkg" "Building package ($((pkg_cur+=1))/$pkg_total)"
 
         run_hook pre-extract "$pkg" "$pkg_dir/$pkg"
         pkg_extract "$pkg"

--- a/kiss
+++ b/kiss
@@ -37,17 +37,8 @@ as_root() {
     [ "$uid" = 0 ] || log "Using '${su:=su}' (to become ${user:=root})"
 
     case ${su##*/} in
-        doas|sudo|ssu)
-            "$su" -u "$user" -- env "$@"
-        ;;
-
-        su)
-            "$su" -c "env $* <&3" "$user" 3<&0 </dev/tty
-        ;;
-
-        *)
-            die "Invalid KISS_SU value: ${su##*/} (valid: doas, sudo, ssu, su)"
-        ;;
+        su) "$su" -c "env $* <&3" "$user" 3<&0 </dev/tty ;;
+        *) "$su" -u "$user" -- env "$@" ;;
     esac
 }
 

--- a/kiss
+++ b/kiss
@@ -465,8 +465,8 @@ pkg_fix_deps() {
             case $line in
                 *NEEDED*\[*\] | *'=>'*)
                     # readelf: 0x0000 (NEEDED) Shared library: [libjson-c.so.5]
-                    line=${line##*[}
-                    line=${line%%]*}
+                    line=${line##*\[}
+                    line=${line%%\]*}
 
                     # ldd:     libjson-c.so.5 => /lib/libjson-c.so.5 ...
                     line=${line##*=> }

--- a/kiss
+++ b/kiss
@@ -1304,7 +1304,7 @@ pkg_updates() {
     for repo do
         # Go to the root of the repository (if it exists).
         if ! cd "$repo" 2>/dev/null; then
-            log "Skipping "$repo", not a directory"; continue
+            log "Skipping $repo, not a directory"; continue
         fi
 
         case $(git remote 2>/dev/null) in

--- a/kiss
+++ b/kiss
@@ -2,7 +2,7 @@
 # shellcheck source=/dev/null
 #
 # This is a simple package manager written in POSIX shell for use
-# in KISS Linux (https://k1ss.org).
+# in KISS Linux (https://k1sslinux.org).
 #
 # Created by Dylan Araps.
 

--- a/kiss
+++ b/kiss
@@ -1123,7 +1123,7 @@ pkg_remove() {
     [ "$KISS_FORCE" = 1 ] || {
         log "$1" "Checking for reverse dependencies"
 
-        (cd "$sys_db"; set +f; grep -lFx "$1" -- */depends) &&
+        (cd "$sys_db"; set +f; grep -lFx -- "$1" */depends) &&
             die "$1" "Can't remove package, others depend on it"
     }
 

--- a/kiss
+++ b/kiss
@@ -1551,7 +1551,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.2.1\n' ;;
+        v|version)  printf '5.2.2\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'

--- a/kiss
+++ b/kiss
@@ -37,7 +37,7 @@ as_root() {
     [ "$uid" = 0 ] || log "Using '${su:=su}' (to become ${user:=root})"
 
     case ${su##*/} in
-        doas|sudo|sls)
+        doas|sudo|ssu)
             "$su" -u "$user" -- env "$@"
         ;;
 
@@ -46,7 +46,7 @@ as_root() {
         ;;
 
         *)
-            die "Invalid KISS_SU value: $su (valid: doas, sudo, sls, su)"
+            die "Invalid KISS_SU value: ${su##*/} (valid: doas, sudo, ssu, su)"
         ;;
     esac
 }
@@ -1360,7 +1360,7 @@ pkg_updates() {
                             # on the other hand requires that each argument be
                             # properly quoted as the command passed to it must
                             # be a string... This sets quotes where needed.
-                            case $su in *su) git_cmd="'$git_cmd'"; esac
+                            case ${su##*/} in su) git_cmd="'$git_cmd'"; esac
 
                             # Spawn a subshell to run multiple commands as
                             # root at once. This makes things easier on users
@@ -1635,7 +1635,7 @@ main() {
 
     # Figure out which 'sudo' command to use based on the user's choice or what
     # is available on the system.
-    su=${KISS_SU:-"$(command -v sudo || command -v doas || command -v sls)"} ||:
+    su=${KISS_SU:-"$(command -v sudo || command -v doas || command -v ssu)"} ||:
 
     # Figure out which utility is available to dump elf information.
     elf_cmd=${KISS_ELF:="$(

--- a/kiss
+++ b/kiss
@@ -535,7 +535,11 @@ pkg_manifest() (
     #       contents.
     # sed:  Remove the first character in each line (./dir -> /dir) and
     #       remove all lines which only contain '.'.
-    find . -type d -exec printf '%s/\n' {} + -o -print | sort -r |
+    {
+        find . -type d -exec printf '%s/\n' {} +
+        find . ! -type d -print
+
+    } | sort -r |
         sed '/^\.\/$/d;ss.ss' > "${2:-$pkg_dir}/$1/$pkg_db/$1/manifest"
 )
 

--- a/kiss
+++ b/kiss
@@ -1637,7 +1637,7 @@ main() {
 
     # Figure out which 'sudo' command to use based on the user's choice or what
     # is available on the system.
-    su=${KISS_SU:-"$(command -v sudo || command -v doas || command -v ssu)"} ||:
+    su=${KISS_SU:-"$(command -v sudo || command -v doas || command -v ssu)"} || su=su
 
     # Figure out which utility is available to dump elf information.
     elf_cmd=${KISS_ELF:="$(

--- a/kiss
+++ b/kiss
@@ -1550,7 +1550,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.2.2\n' ;;
+        v|version)  printf '5.2.3\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'

--- a/kiss
+++ b/kiss
@@ -625,7 +625,7 @@ pkg_build() {
     log "Building: $*"
 
     # Only ask for confirmation if more than one package needs to be built.
-    [ "$#" -gt 1 ] || [ "$pkg_update" ] && prompt
+    [ "$#" -gt 1 ] || [ "$pkg_update" ] && { prompt || exit 0 ;}
 
     for pkg do pkg_lint "$pkg"; done
 
@@ -1400,7 +1400,7 @@ pkg_updates() {
         log "Detected package manager update"
         log "The package manager will be updated first"
 
-        prompt
+        prompt || exit 0
 
         pkg_build kiss
         args i kiss

--- a/kiss
+++ b/kiss
@@ -122,6 +122,8 @@ sh256() {
             shasum -a 256           "$1" ||
             digest -a sha256        "$1"
         ) 2>/dev/null
+
+        printf '%s\n' "${hash%% *}"
     fi
 }
 

--- a/kiss
+++ b/kiss
@@ -115,7 +115,7 @@ sh256() {
     # Example: '<checksum>  <file>'
 
     # Skip non-files and broken symlinks.
-    if { [ -h "$1" ] && [ -e "$1" ] } || [ -f "$1" ]; then
+    if { [ -h "$1" ] && [ -e "$1" ]; } || [ -f "$1" ]; then
         hash=$(
             sha256sum               "$1" ||
             sha256 -r               "$1" ||

--- a/kiss
+++ b/kiss
@@ -1374,11 +1374,6 @@ pkg_updates() {
                 }
             ;;
         esac
-
-        [ ! -x update ] || {
-            log "$PWD" "Running update hook"
-            ./update
-        }
     done
 
     log "Checking for new package versions"

--- a/kiss
+++ b/kiss
@@ -1304,7 +1304,9 @@ pkg_updates() {
     # Update each repository in '$KISS_PATH'.
     for repo do
         # Go to the root of the repository (if it exists).
-        cd "$repo"
+        if ! cd "$repo" 2>/dev/null; then
+            log "Skipping "$repo", not a directory"; continue
+        fi
 
         case $(git remote 2>/dev/null) in
             "")

--- a/kiss
+++ b/kiss
@@ -1616,7 +1616,7 @@ main() {
 
     # Allow the user to disable colors in output via an environment variable.
     # Check this once so as to not slow down printing.
-    [ "$KISS_COLOR" = 0 ] || lcol='\033[1;33m' lcol2='\033[1;34m' lclr='\033[m'
+    [ "$KISS_COLOR" = 0 ] || ! [ -t 1 ] || lcol='\033[1;33m' lcol2='\033[1;34m' lclr='\033[m'
 
     # Store the original working directory to ensure that relative paths
     # passed by the user on the command-line properly resolve to locations

--- a/kiss
+++ b/kiss
@@ -1547,7 +1547,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.2.3\n' ;;
+        v|version)  printf '5.2.4\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'

--- a/kiss
+++ b/kiss
@@ -113,7 +113,7 @@ sh256() {
     # All utilities must match 'sha256sum' output.
     #
     # Example: '<checksum>  <file>'
-    [ -e "$1" ] || return 0
+    [ -f "$1" ] || return 0
 
     hash=$(
         sha256sum               "$1" ||
@@ -121,7 +121,7 @@ sh256() {
         openssl dgst -sha256 -r "$1" ||
         shasum -a 256           "$1" ||
         digest -a sha256        "$1"
-    ) 2>/dev/null
+    )
 
     printf '%s\n' "${hash%% *}"
 }

--- a/kiss
+++ b/kiss
@@ -113,17 +113,19 @@ sh256() {
     # All utilities must match 'sha256sum' output.
     #
     # Example: '<checksum>  <file>'
-    [ -f "$1" ] || return 0
 
-    hash=$(
-        sha256sum               "$1" ||
-        sha256 -r               "$1" ||
-        openssl dgst -sha256 -r "$1" ||
-        shasum -a 256           "$1" ||
-        digest -a sha256        "$1"
-    )
+    # Skip non-files and broken symlinks.
+    if { [ -h "$1" ] && [ -e "$1" ] } || [ -f "$1" ]; then
+        hash=$(
+            sha256sum               "$1" ||
+            sha256 -r               "$1" ||
+            openssl dgst -sha256 -r "$1" ||
+            shasum -a 256           "$1" ||
+            digest -a sha256        "$1"
+        )
 
-    printf '%s\n' "${hash%% *}"
+        printf '%s\n' "${hash%% *}"
+    fi
 }
 
 pkg_lint() {

--- a/kiss
+++ b/kiss
@@ -114,17 +114,14 @@ sh256() {
     #
     # Example: '<checksum>  <file>'
 
-    # Skip non-files and broken symlinks.
-    if { [ -h "$1" ] && [ -e "$1" ]; } || [ -f "$1" ]; then
+    if [ ! -d "$1" ] && [ -e "$1" ]; then
         hash=$(
             sha256sum               "$1" ||
             sha256 -r               "$1" ||
             openssl dgst -sha256 -r "$1" ||
             shasum -a 256           "$1" ||
             digest -a sha256        "$1"
-        )
-
-        printf '%s\n' "${hash%% *}"
+        ) 2>/dev/null
     fi
 }
 

--- a/kiss
+++ b/kiss
@@ -868,7 +868,7 @@ pkg_conflicts() {
     # Store the list of found conflicts in a file as we'll be using the
     # information multiple times. Storing things in the cache dir allows
     # us to be lazy as they'll be automatically removed on script end.
-    grep -Fxf "$mak_dir/$pid-m" -- "$@" 2>/dev/null > "$mak_dir/$pid-c" ||:
+    sed '/\/$/d' "$@" | sort "$mak_dir/$pid-m" - | uniq -d > "$mak_dir/$pid-c" ||:
 
     # Enable alternatives automatically if it is safe to do so.
     # This checks to see that the package that is about to be installed
@@ -899,7 +899,7 @@ pkg_conflicts() {
         # this work.
         #
         # Pretty nifty huh?
-        while IFS=: read -r _ con; do
+        while read -r con; do
             printf '%s\n' "Found conflict $con"
 
             # Create the "choices" directory inside of the tarball.

--- a/kiss
+++ b/kiss
@@ -96,6 +96,16 @@ decompress() {
     esac < "$1"
 }
 
+sum_type() {
+    if [ -f "$1" ]; then
+        _chk_b3sum=
+        _chk_file=$1
+    else
+        _chk_b3sum=false
+        _chk_file=$1s
+    fi
+}
+
 sh256() {
     # There's no standard utility to generate sha256 checksums.
     # This is a simple wrapper around sha256sum, sha256, shasum,
@@ -107,6 +117,7 @@ sh256() {
 
     if [ ! -d "$1" ] && [ -e "$1" ]; then
         hash=$(
+            "${_chk_b3sum:-b3sum}" "$1" ||
             sha256sum               "$1" ||
             sha256 -r               "$1" ||
             openssl dgst -sha256 -r "$1" ||
@@ -576,8 +587,8 @@ pkg_etcsums() (
     # This can't be a simple 'find -exec' as 'sh256' is a shell function
     # and not a real command of any kind. This is the shell equivalent.
     find etc ! -type d | sort | while read -r line; do
-        sh256 "$line"
-    done > "$pkg_dir/$1/$pkg_db/$1/etcsums"
+        _chk_b3sum=; sh256 "$line"
+    done > "$pkg_dir/$1/$pkg_db/$1/etcsum"
 )
 
 pkg_tar() (
@@ -730,7 +741,7 @@ pkg_build() {
 
         # If the package contains '/etc', add a file called 'etcsums' to the
         # manifest. See comment directly above.
-        [ -d "$pkg_dir/$pkg/etc" ] && : > "$pkg_dir/$pkg/$pkg_db/$pkg/etcsums"
+        [ -d "$pkg_dir/$pkg/etc" ] && : > "$pkg_dir/$pkg/$pkg_db/$pkg/etcsum"
 
         pkg_strip    "$pkg"
         pkg_manifest "$pkg"
@@ -752,7 +763,7 @@ pkg_build() {
 
     if [ "$pkg_update" ]; then
         return
-    else 
+    else
         prompt "Install built packages? [$*]" && args i "$@"
     fi
 }
@@ -791,25 +802,23 @@ pkg_checksums() {
 pkg_verify() {
     # Verify all package checksums. This is achieved by generating a new set
     # of checksums and then comparing those with the old set.
-    verify_cmd="
-    NR==FNR{a[\$1];next}/^git  .*|^SKIP$/{next}!((\$1)in a){exit 1}
-    "
+    verify_cmd="NR==FNR{a[\$1];next}/^SKIP$/{next}!((\$1)in a){exit 1}"
 
     for pkg do
         repo_dir=$(pkg_find "$pkg")
 
         [ -f "$repo_dir/sources" ] || continue
 
+        sum_type "$repo_dir/checksum"
         verify_sum=$(pkg_checksums "$pkg")
-
         [ "$verify_sum" ] || continue
-        [ -f "$repo_dir/checksums" ] || die "$pkg" "checksums file missing"
+        [ -f "$_chk_file" ] || die "$pkg" "checksums file missing"
 
         # Check that the first column (separated by whitespace) match in both
         # checksum files. If any part of either file differs, mismatch. Abort.
         printf '%s\n' "$verify_sum" |
 
-        awk "$verify_cmd" - "$repo_dir/checksums" || {
+        awk "$verify_cmd" - "$_chk_file" || {
             log "$pkg" "Checksum mismatch"
 
             # Instead of dying above, log it to the terminal. Also define a
@@ -1161,7 +1170,8 @@ pkg_remove() {
     fi
 
     # Make a backup of the etcsums file (if it exists).
-    cp -f "$sys_db/$1/etcsums" "$mak_dir/c" 2>/dev/null ||:
+    sum_type "$sys_db/$1/etcsum"
+    cp -f "$_chk_file" "$mak_dir/c" 2>/dev/null ||:
 
     log "$1" "Removing package"
     pkg_remove_files < "$sys_db/$1/manifest"
@@ -1264,7 +1274,8 @@ pkg_install() {
     # If the package is already installed (and this is an upgrade) make a
     # backup of the manifest and etcsums files.
     cp -f "$sys_db/$pkg_name/manifest" "$mak_dir/m" 2>/dev/null ||:
-    cp -f "$sys_db/$pkg_name/etcsums"  "$mak_dir/c" 2>/dev/null ||:
+    sum_type "$sys_db/$pkg_name/etcsum"
+    cp -f "$_chk_file" "$mak_dir/c" 2>/dev/null ||:
 
     # Install the package's files by iterating over its manifest.
     pkg_install_files -z "$tar_dir/$pkg_name"
@@ -1533,7 +1544,7 @@ args() {
                     continue
                 }
 
-                sums=$(pkg_checksums "$pkg")
+                sums=$(_chk_b3sum=; pkg_checksums "$pkg")
 
                 [ "$sums" ] || {
                     log "$pkg" "No sources needing checksums"
@@ -1544,14 +1555,15 @@ args() {
                 # shellcheck disable=2188
                 printf '%s\n' "$sums" |
 
-                if 2>/dev/null >> "$repo_dir/checksums"; then
-                    tee "$repo_dir/checksums"
-
+                if 2>/dev/null >> "$repo_dir/checksum"; then
+                    tee "$repo_dir/checksum"
+                    rm -f "$repo_dir/checksums"
                 else
                     log "$pkg" "Need permissions to generate checksums"
                     file_owner "$repo_dir"
 
-                    user=$user as_root tee "$repo_dir/checksums"
+                    user=$user as_root \
+                        sh -c "tee '$repo_dir/checksum' && rm -f '$repo_dir/checksums'"
                 fi
 
                 log "$pkg" "Generated checksums"

--- a/kiss
+++ b/kiss
@@ -219,10 +219,17 @@ pkg_sources() {
             log "$1" "Downloading $src"
             mkdir -p "$PWD/$dest"
 
+            # We don't want interrupt to exit immediately here, so we change the
+            # behaviour here.
+            trap pkg_clean INT
+
             curl "$src" -fLo "./${dest:-.}/${src##*/}" || {
                 rm -f "./${dest:-.}/${src##*/}"
                 die "$1" "Failed to download $src"
             }
+
+            # Restore the trap to the original value.
+            trap 'pkg_clean; exit 1' INT
 
         # Local source (relative).
         elif [ -e "$repo_dir/$src" ]; then

--- a/kiss
+++ b/kiss
@@ -1572,7 +1572,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.3.1\n' ;;
+        v|version)  printf '5.3.2\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'


### PR DESCRIPTION
NOTE: I have tested this change locally and it works fine. Please try it
and let me know if you encounter any issues.

With this commit, the package manager will use blake3 (b3sum) for all
checksum verification. The rationale for this change is one of
performance with blake3 beating out sha256 in every case.

This requires that the repository package for the package manager now
depend on b3sum (https://git.sr.ht/~mcf/b3sum (my option) or
https://github.com/BLAKE3-team/BLAKE3). I recommend this be statically
linked.

This change is intentionally unintrusive as it is transitional. Existing
checksums will continue to be verifiable and no changes are needed for
things to continue to work as usual.

Any newly generated checksums will use blake3. As packages have their
checksums updated, sha256 will slowly but seamlessly disappear.

There is a little nuance to the way this transition process works.

1. Existing checksum files are called 'checksums'.
2. New checksum files are called 'checksum'.
3. Existing etcsum files are called 'etcsums'.
4. New etcsum files are called 'etcsum'.

This is the ~~best~~ only way I found to differentiate. Happy to hear other 
ideas. I also personally prefer the new naming to the old one (superfluous plural).

Once sha256 checksums have vanished, the package manager's code can be
further simplified and we can drop the multiple sha256 implementation nonsense.

Benchmarks:

-> du -sh linux-5.12.6.tar.zst
170.6M  linux-5.12.6.tar.zst
-> time sha256sum linux-5.12.6.tar.zst >/dev/null
    0m01.11s real     0m00.98s user     0m00.13s system
-> time b3sum linux-5.12.6.tar.zst >/dev/null
    0m00.14s real     0m00.11s user     0m00.02s system

-> du -sh wlroots-0.13.0.tar.zst
520.0K  wlroots-0.13.0.tar.zst
-> time sha256sum wlroots-0.13.0.tar.zst >/dev/null
    0m00.00s real     0m00.00s user     0m00.00s system
-> time b3sum wlroots-0.13.0.tar.zst >/dev/null
    0m00.00s real     0m00.00s user     0m00.00s system

-> du -sh llvm-12.0.0.src.tar.zst
61.8M   llvm-12.0.0.src.tar.zst
-> time sha256sum llvm-12.0.0.src.tar.zst >/dev/null
    0m00.43s real     0m00.38s user     0m00.05s system
-> time b3sum llvm-12.0.0.src.tar.zst >/dev/null
    0m00.05s real     0m00.05s user     0m00.00s system