### PR TITLE
kiss: circular dependency detection

### DIFF
--- a/kiss
+++ b/kiss
@@ -366,12 +366,19 @@ pkg_depends() {
     # dependencies are listed first and then the parents in reverse order.
     contains "$deps" "$1" || {
         # Filter out non-explicit, aleady installed dependencies.
-        [ "$3" ] && [ -z "$2" ] && (pkg_list "$1" >/dev/null) && return
+        [ "$3" ] && [ -z "$2" ] && (pkg_list "$1" >/dev/null 2>&1) && return
+
+        # Detect circular dependencies and bail out.
+        case $4 in *"$1 ${4##* } $1 ${4##* } $1"*)
+            die "Circular dependency detected $1 <> ${4##* }"
+        esac
+
+        _f=$(pkg_find "$1" 2>/dev/null)/depends ||:
 
         # Recurse through the dependencies of the child packages.
-        while read -r dep _ || [ "$dep" ]; do
-            [ "${dep##\#*}" ] && pkg_depends "$dep" '' "$3"
-        done 2>/dev/null < "$(pkg_find "$1")/depends" ||:
+        ! [ -e "$_f" ] || while read -r dep _ || [ "$dep" ]; do
+            [ "${dep##\#*}" ] && pkg_depends "$dep" '' "$3" "$4 $1"
+        done < "$_f" ||:
 
         # After child dependencies are added to the list,
         # add the package which depends on them.
@@ -752,7 +759,7 @@ pkg_build() {
 
     if [ "$pkg_update" ]; then
         return
-    else 
+    else
         prompt "Install built packages? [$*]" && args i "$@"
     fi
 }


### PR DESCRIPTION
This makes the package manager cleanly exit when circular dependencies
are found rather than segfaulting (in some shells)

I changed the output redirection behavior slightly (no more global
stderr suppression) to allow the error message to appear. It now also checks
for file existence before attempting to read (we would silently ignore read
errors).