### PR TITLE
kiss: remove broken directory symlinks

### DIFF
--- a/kiss
+++ b/kiss
@@ -752,7 +752,7 @@ pkg_build() {
 
     if [ "$pkg_update" ]; then
         return
-    else 
+    else
         prompt "Install built packages? [$*]" && args i "$@"
     fi
 }
@@ -1066,21 +1066,28 @@ pkg_remove_files() {
             }
         esac 2>/dev/null ||:
 
-        file=$KISS_ROOT/$file
+        _file=$KISS_ROOT${file%%/}
 
-        # Remove files.
-        if [ -f "$file" ] && [ ! -h "$file" ]; then
-            rm -f "$file"
+        # Queue all directory symlinks for later removal.
+        if [ -h "$_file" ] && [ -d "$_file" ]; then
+            case $file in /*/*/)
+                set -- "$@" "$_file"
+            esac
 
-        # Remove file symlinks.
-        elif [ -h "$file" ] && [ ! -d "$file" ]; then
-            rm -f "$file"
+        # Remove empty directories.
+        elif [ -d "$_file" ]; then
+            rmdir "$_file" 2>/dev/null ||:
 
-        # Remove directories if empty.
-        elif [ -d "$file" ] && [ ! -h "$file" ]; then
-            rmdir "$file" 2>/dev/null ||:
+        # Remove everything else.
+        else
+            rm -f "$_file"
         fi
     done ||:
+
+    # Remove all broken directory symlinks.
+    for sym do
+        [ -e "$sym" ] || rm -f "$sym"
+    done
 }
 
 pkg_etc() (


### PR DESCRIPTION
This changes pkg_remove_files to queue all directory symlinks for
removal *after* all other items. Links are only removed if they are
broken and a safeguard has been added for root level directories.

Also fixed are some bugs around how the paths are stored internally.

1. If KISS_ROOT is empty, path ends up being //path/to/file.
2. Directory symlinks are undetectable when they have '/' as a suffix.

Let me know if there are any issues :)

Closes #23 