### PR TITLE
pkg_install_files: fix internal path issue.

### DIFF
--- a/kiss
+++ b/kiss
@@ -752,7 +752,7 @@ pkg_build() {
 
     if [ "$pkg_update" ]; then
         return
-    else 
+    else
         prompt "Install built packages? [$*]" && args i "$@"
     fi
 }
@@ -1004,11 +1004,11 @@ pkg_install_files() {
     # going down the tree.
     sort "$2/$pkg_db/${2##*/}/manifest" |
 
-    while read -r line; do
+    while read -r file; do
         # Grab the octal permissions so that directory creation
         # preserves permissions.
         # See: [2] at top of script.
-        rwx=$(ls -ld "$2/$line") oct='' b='' o=0
+        rwx=$(ls -ld "$2/${file#/}") oct='' b='' o=0
 
         # Convert the output of 'ls' (rwxrwx---) to octal. This is simply
         # a 1-9 loop with the second digit being the value of the field.
@@ -1024,28 +1024,29 @@ pkg_install_files() {
             [ "$((${c%?} % 3))" = 0 ] && oct=$oct$o o=0
         done
 
+        _file=$KISS_ROOT/${file#/}
+
         # Copy files and create directories (preserving permissions),
         # skipping anything located in /etc/.
         #
         # The 'test' will run with '-e' for no-overwrite and '-z'
         # for overwrite.
-        case $line in /etc/*) ;;
+        case $file in /etc/*) ;;
             */)
                 # Skip directories if they already exist in the file system.
                 # (Think /usr/bin, /usr/lib, etc).
-                [ -d "$KISS_ROOT/$line" ] || mkdir -m "$oct" "$KISS_ROOT/$line"
+                [ -d "$_file" ] || mkdir -m "$oct" "$_file"
             ;;
 
             *)
                 # Skip directories as they're likely symlinks in this case.
                 # Pure directories in manifests have a suffix of '/'.
-                [ -d "$KISS_ROOT/$line" ] || test "$1" "$KISS_ROOT/$line" || {
-                    cp -fP "$2/$line" "$KISS_ROOT/$line"
+                [ -d "$_file" ] || test "$1" "$_file" || {
+                    cp -fP "$2/${file#/}" "$_file"
 
                     # Skip changing permissions of symlinks. This prevents
                     # errors when the symlink exists prior to the target.
-                    [ -h "$KISS_ROOT/$line" ] ||
-                        chmod "$b$oct" "$KISS_ROOT/$line"
+                    [ -h "$_file" ] || chmod "$b$oct" "$_file"
                 }
         esac
     done ||:


### PR DESCRIPTION
When KISS_ROOT is empty path is //path/to/file.