### PR TITLE
kiss: do a less shallow clone to enable 'git describe'

### DIFF
--- a/kiss
+++ b/kiss
@@ -270,7 +270,7 @@ pkg_extract() {
                 log "$1" "Cloning ${url%[#@]*}"; {
                     git init
                     git remote add origin "${url%[#@]*}"
-                    git fetch -t --depth 1 origin "$com" || git fetch -t
+                    git fetch -t --filter=tree:0 origin "$com" || git fetch -t
                     git -c advice.detachedHead=0 checkout "${com:-FETCH_HEAD}"
                 } || die "$1" "Failed to clone $src"
             ;;
@@ -752,7 +752,7 @@ pkg_build() {
 
     if [ "$pkg_update" ]; then
         return
-    else 
+    else
         prompt "Install built packages? [$*]" && args i "$@"
     fi
 }


### PR DESCRIPTION
This downloads all reachable commits and then blobs and trees on demand. It
swaps the clone from shallow to treeless. In other words, it's a less
shallow shallow clone which makes 'git describe' work.

Fixes https://github.com/kiss-community/kiss/issues/18