### PR TITLE
kiss: fix bugs with pkg_build 

### DIFF
--- a/kiss
+++ b/kiss
@@ -611,8 +611,6 @@ pkg_build() {
 
     log "Resolving dependencies"
 
-    nexplicit="$#"
-
     # Mark packages passed on the command-line separately from those
     # detected as dependencies. We need to treat explicitly passed packages
     # differently from those pulled in as dependencies.
@@ -630,22 +628,24 @@ pkg_build() {
     # and instead install pre-built binaries if they exist.
     [ "$pkg_update" ] || explicit_build=$explicit
 
+    set --
+
     # If an explicit package is a dependency of another explicit package,
     # remove it from the explicit list as it needs to be installed as a
     # dependency.
-    for pkg do
-        contains "$deps" "$pkg" || explicit2=" $explicit2 $pkg "
+    for pkg in $explicit; do
+        contains "$deps" "$pkg" || set -- "$@" "$pkg"
     done
-    explicit=$explicit2
+    explicit_cnt=$#
+
+    log "Building: explicit: $*${deps:+, implicit: ${deps## }}"
 
     # See [1] at top of script.
     # shellcheck disable=2046,2086
-    set -- $deps $explicit
-
-    log "Building: $*"
+    set -- $deps "$@"
 
     # Only ask for confirmation if dependencies need to be built.
-    [ "$#" -ne "$nexplicit" ] || [ "$pkg_update" ] && prompt
+    [ "$#" -ne "$explicit_cnt" ] || [ "$pkg_update" ] && prompt
 
     for pkg do pkg_lint "$pkg"; done
 
@@ -752,7 +752,7 @@ pkg_build() {
 
     if [ "$pkg_update" ]; then
         return
-    else 
+    else
         prompt "Install built packages? [$*]" && args i "$@"
     fi
 }


### PR DESCRIPTION
Duplicates were not filtered out of the argument list as originally
intended due to the creation of $explicit2 disregarding $explicit.
The total package count is now aware of duplicates also.

The total package count (previously nexplicit) would also incorrectly
count packages which were removed from the explicit list. It would
silently /not prompt/ when a package went from explicit to implicit.

I have also updated the output to reflect whether a package is
explicit or implicit. ie, whether it's a dependency or not.