### PR TITLE
kiss: Fix incorrect check during updates

### DIFF
--- a/kiss
+++ b/kiss
@@ -752,7 +752,7 @@ pkg_build() {
 
     if [ "$pkg_update" ]; then
         return
-    else 
+    else
         prompt "Install built packages? [$*]" && args i "$@"
     fi
 }
@@ -1328,10 +1328,12 @@ pkg_updates() {
 
     # Update each repository in '$KISS_PATH'.
     for repo do
-        # Go to the root of the repository (if it exists).
-        if ! cd "$repo" 2>/dev/null; then
-            log "Skipping $repo, not a directory"; continue
-        fi
+        [ -d "$repo" ] || {
+            log "$repo" " "
+            printf 'Skipping repository, not a directory\n'
+            continue
+        }
+        cd "$repo"
 
         case $(git remote 2>/dev/null) in
             "")


### PR DESCRIPTION
Wrapping the cd call and hiding its stderr is wrong as we now skip
directories which exist but are inaccessible. The error message
is also misleadingly "not a directory" instead of "permission denied"
(or whatever else it may be). This works fine with broken symlinks.

Current master:

```
# Repository which doesn't exist.
-> KISS_PATH=/test ./kiss u
-> Updating repositories 
-> Skipping /test, not a directory 
-> Checking for new package versions 
-> Everything is up to date 

# Repository which is inaccessible. 
-> KISS_PATH=/root ./kiss u 
-> Updating repositories 
-> Skipping /root, not a directory 
-> Checking for new package versions 
-> Everything is up to date 

# Repository which is a broken symlink.
-> KISS_PATH=$HOME/test_broken_symlink ./kiss u
-> Updating repositories 
-> Skipping /home/dylan/test_broken_symlink, not a directory 
-> Checking for new package versions 
-> Everything is up to date 
```

This PR:

```
# Repository which doesn't exist.
-> KISS_PATH=/test ./kiss u 
-> Updating repositories 
-> /test  
Skipping repository, not a directory
-> Checking for new package versions 
-> Everything is up to date 

# Repository which is inaccessible.
-> KISS_PATH=/root ./kiss u 
-> Updating repositories 
./kiss[1705]: cd: /root - Permission denied

# Repository which is a broken symlink.
-> KISS_PATH=$HOME/test_broken_symlink ./kiss u 
-> Updating repositories 
-> /home/dylan/test_broken_symlink  
Skipping repository, not a directory
-> Checking for new package versions 
-> Everything is up to date 
```