### PR TITLE
Make kiss update scriptable

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 |/
-|\ISS                                                           https://k1ss.org
+|\ISS                                                      https://k1sslinux.org
 ________________________________________________________________________________
 
 
@@ -8,5 +8,5 @@ ________________________________________________________________________________
 
 KISS' tiny package manager.
 
-Documentation: https://k1ss.org/package-manager
-               https://k1ss.org/package-system
+Documentation: https://k1sslinux.org/package-manager
+               https://k1sslinux.org/package-system

--- a/contrib/kiss-chroot
+++ b/contrib/kiss-chroot
@@ -11,8 +11,12 @@ die() {
 }
 
 clean() {
-    log Unmounting /dev, /proc and /sys from chroot; {
+    log Unmounting host filesystems; {
         umount "$1/sys/firmware/efi/efivars" 2>/dev/null ||:
+        umount "$1/tmp" ||:
+        umount "$1/run" ||:
+        umount "$1/dev/pts" ||:
+        umount "$1/dev/shm" ||:
         umount "$1/dev"  ||:
         umount "$1/proc" ||:
         umount "$1/sys"  ||:
@@ -35,19 +39,33 @@ mounted() {
         [ "$target" = "$1" ] && return 0
     done < /proc/mounts
 
+    printf 'mounting %s\n' "$1" >&2
     return 1
 }
 
+set -- "${1%"${1##*[!/]}"}"
 [ -z "$1" ]        && die Need a path to the chroot
 [ -d "$1" ]        || die Given path does not exist
 [ "$(id -u)" = 0 ] || die Script needs to be run as root
 
 trap 'clean "$1"' EXIT INT
 
-log Mounting /dev, /proc and /sys from host; {
+log Mounting host filesystems; {
     mounted "$1/dev"  || mount -o bind /dev "$1/dev"  ||:
     mounted "$1/proc" || mount -t proc proc "$1/proc" ||:
     mounted "$1/sys"  || mount -t sysfs sys "$1/sys"  ||:
+
+    mounted "$1/dev/shm" ||
+        mount -t tmpfs shmfs "$1/dev/shm"  ||:
+
+    mounted "$1/dev/pts" ||
+        mount -o bind /dev/pts "$1/dev/pts"  ||:
+
+    mounted "$1/tmp" ||
+        mount -o mode=1777,nosuid,nodev -t tmpfs tmpfs "$1/tmp"  ||:
+
+    mounted "$1/run" ||
+        mount -t tmpfs tmpfs "$1/run"  ||:
 
     mounted "$1/sys/firmware/efi/efivars" ||
         mount -t efivarfs efivarfs "$1/sys/firmware/efi/efivars" 2>/dev/null ||:

--- a/contrib/kiss-owns
+++ b/contrib/kiss-owns
@@ -4,7 +4,7 @@
 # Follow symlinks to any paths.
 case $1 in
     /*)
-        cd -P "$KISS_ROOT/${1%/*}"
+        cd -P "$KISS_ROOT${1%/*}"
     ;;
 
     */*)

--- a/contrib/kiss-size
+++ b/contrib/kiss-size
@@ -27,7 +27,8 @@ kiss list "${1:-null}" >/dev/null || {
 
 # Filter directories from manifest and leave only files.
 # Directories in the manifest end in a trailing '/'.
-files=$(sed 's|.*/$||' "$KISS_ROOT/var/db/kiss/installed/$1/manifest")
+files=$(sed -e "s|^|$KISS_ROOT|" -e "s|.*/$||" \
+        "$KISS_ROOT/var/db/kiss/installed/$1/manifest")
 
 # Send the file list to 'du'.
 # This unquoted variable is safe as word splitting is intended

--- a/kiss
+++ b/kiss
@@ -463,7 +463,7 @@ pkg_fix_deps() {
         # fullpath of a library when using readelf. Best use we have here is
         # saving it in a buffer, so we don't use the dynamic loader everytime we
         # need to reference it.
-        lddbuf=$(ldd -- "$file" 2>/dev/null)
+        lddbuf=$(ldd -- "$file" 2>/dev/null) ||:
 
         case $elf_cmd in
             *readelf)

--- a/kiss
+++ b/kiss
@@ -1538,7 +1538,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.2.4\n' ;;
+        v|version)  printf '5.2.6\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'

--- a/kiss
+++ b/kiss
@@ -745,12 +745,8 @@ pkg_build() {
 
     if [ "$pkg_update" ]; then
         return
-
-    elif [ "$#" -gt 1 ] && prompt "Install built packages? [$*]"; then
-        args i "$@"
-
-    else
-        log "Run 'kiss i $*' to install the package(s)"
+    else 
+        prompt "Install built packages? [$*]" && args i "$@"
     fi
 }
 

--- a/kiss
+++ b/kiss
@@ -1546,7 +1546,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.2.7\n' ;;
+        v|version)  printf '5.2.8\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'

--- a/kiss
+++ b/kiss
@@ -91,7 +91,7 @@ decompress() {
         *.lz)       lzip -dc  ;;
         *.tar)      cat       ;;
         *.tgz|*.gz) gzip -d   ;;
-        *.xz|*.txz) xz -dcT 0 ;;
+        *.xz|*.txz) xz -dcT0  ;;
         *.zst)      zstd -dc  ;;
     esac < "$1"
 }
@@ -571,7 +571,7 @@ pkg_tar() (
         gz)   gzip -6  ;;
         lzma) lzma -z  ;;
         lz)   lzip -z  ;;
-        xz)   xz -zT 0 ;;
+        xz)   xz -zT0  ;;
         zst)  zstd -z  ;;
     esac > "$bin_dir/$1@$version-$release.tar.${KISS_COMPRESS:=gz}"
 

--- a/kiss
+++ b/kiss
@@ -1372,8 +1372,8 @@ pkg_updates() {
     set +f --
 
     for pkg in "$sys_db/"*; do
-        read -r db_ver db_rel < "$pkg/version"
-        read -r re_ver re_rel < "$(pkg_find "${pkg##*/}")/version"
+        read -r db_ver db_rel < "$pkg/version" || exit 1
+        read -r re_ver re_rel < "$(pkg_find "${pkg##*/}")/version" || exit 1
 
         # Compare installed packages to repository packages.
         [ "$db_ver-$db_rel" = "$re_ver-$re_rel" ] || {

--- a/kiss
+++ b/kiss
@@ -1544,7 +1544,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.2.6\n' ;;
+        v|version)  printf '5.2.7\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'

--- a/kiss
+++ b/kiss
@@ -687,7 +687,7 @@ pkg_build() {
         run_hook pre-build "$pkg" "$pkg_dir/$pkg"
 
         # Call the build script, log the output to the terminal and to a file.
-        # There's no PIPEFAIL in POSIX shelll so we must resort to tricks like
+        # There's no PIPEFAIL in POSIX shell so we must resort to tricks like
         # killing the script ourselves.
         { "$repo_dir/build" "$pkg_dir/$pkg" "$build_version" 2>&1 || {
             log "$pkg" "Build failed"
@@ -714,7 +714,7 @@ pkg_build() {
         find "$pkg_dir/$pkg/usr/lib" -name \*.la -exec rm -f {} + 2>/dev/null ||:
 
         # Remove this unneeded file from all packages as it is an endless
-        # source of conflicts. This is used with info pages we we do not support.
+        # source of conflicts. This is used with info pages which we do not support.
         rm -f "$pkg_dir/$pkg/usr/lib/charset.alias"
 
         # Create the manifest file early and make it empty. This ensures that
@@ -1661,7 +1661,7 @@ main() {
     )"} || elf_cmd=ldd
 
     # Store the date and time of script invocation to be used as the name of
-    # the log files the package manager creates uring builds.
+    # the log files the package manager creates during builds.
     time=$(date +%Y-%m-%d-%H:%M)
 
     # Make note of the user's current ID to do root checks later on.

--- a/kiss
+++ b/kiss
@@ -1569,7 +1569,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.2.8\n' ;;
+        v|version)  printf '5.3.0\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'

--- a/kiss
+++ b/kiss
@@ -647,14 +647,17 @@ pkg_build() {
     # Install any pre-built dependencies if they exist in the binary
     # directory and are up to date.
     for pkg do
-        ! contains "$explicit_build" "$pkg" && pkg_cache "$pkg" && {
+        if ! contains "$explicit_build" "$pkg" && pkg_cache "$pkg"; then
             log "$pkg" "Found pre-built binary, installing"
             (KISS_FORCE=1 args i "$tar_file")
-
-            # Remove the now installed package from the build list.
-            shift
-        }
+        else
+            remaining_pkgs=" $remaining_pkgs $pkg"
+        fi
     done
+
+    # See [1] at top of script.
+    # shellcheck disable=2046,2086
+    set -- $remaining_pkgs
 
     for pkg do pkg_sources "$pkg"; done
     pkg_verify "$@"

--- a/kiss
+++ b/kiss
@@ -616,7 +616,7 @@ pkg_build() {
     log "Building: $*"
 
     # Only ask for confirmation if more than one package needs to be built.
-    [ "$#" -gt 1 ] || [ "$pkg_update" ] && { prompt || exit 0 ;}
+    [ "$#" -gt 1 ] || [ "$pkg_update" ] && prompt
 
     for pkg do pkg_lint "$pkg"; done
 
@@ -1136,7 +1136,8 @@ pkg_remove() {
 
     # Reset 'trap' to its original value. Removal is done so
     # we no longer need to block 'Ctrl+C'.
-    trap pkg_clean EXIT INT
+    trap pkg_clean EXIT
+    trap 'pkg_clean; exit 1' INT
 
     log "$1" "Removed successfully"
 }
@@ -1260,7 +1261,8 @@ pkg_install() {
 
     # Reset 'trap' to its original value. Installation is done so we no longer
     # need to block 'Ctrl+C'.
-    trap pkg_clean EXIT INT
+    trap pkg_clean EXIT
+    trap 'pkg_clean; exit 1' INT
 
     if [ -x "$sys_db/$pkg_name/post-install" ]; then
         log "$pkg_name" "Running post-install hook"
@@ -1372,8 +1374,8 @@ pkg_updates() {
     set +f --
 
     for pkg in "$sys_db/"*; do
-        read -r db_ver db_rel < "$pkg/version" || exit 1
-        read -r re_ver re_rel < "$(pkg_find "${pkg##*/}")/version" || exit 1
+        read -r db_ver db_rel < "$pkg/version"
+        read -r re_ver re_rel < "$(pkg_find "${pkg##*/}")/version"
 
         # Compare installed packages to repository packages.
         [ "$db_ver-$db_rel" = "$re_ver-$re_rel" ] || {
@@ -1388,7 +1390,7 @@ pkg_updates() {
         log "Detected package manager update"
         log "The package manager will be updated first"
 
-        prompt || exit 0
+        prompt
 
         pkg_build kiss
         args i kiss
@@ -1619,7 +1621,8 @@ main() {
 
     # Catch errors and ensure that build files and directories are cleaned
     # up before we die. This occurs on 'Ctrl+C' as well as success and error.
-    trap pkg_clean EXIT INT
+    trap pkg_clean EXIT
+    trap 'pkg_clean; exit 1' INT
 
     # Figure out which 'sudo' command to use based on the user's choice or what
     # is available on the system.

--- a/kiss
+++ b/kiss
@@ -435,6 +435,14 @@ pkg_strip() {
     done 2>/dev/null ||:
 }
 
+pkg_fix_deps_fullpath() {
+    # Return the canonical path of libraries extracted by readelf.
+    while read -r dep _ rslv _; do
+        [ "$dep" = "$1" ] || continue
+        printf '%s\n' "$rslv"
+    done
+}
+
 pkg_fix_deps() {
     # Dynamically look for missing runtime dependencies by checking each
     # binary and library with 'ldd'. This catches any extra libraries and or
@@ -451,13 +459,19 @@ pkg_fix_deps() {
     find "$pkg_dir/${PWD##*/}/" -type f 2>/dev/null |
 
     while read -r file; do
+        # We call ldd regardless here, because we also use it to retrieve the
+        # fullpath of a library when using readelf. Best use we have here is
+        # saving it in a buffer, so we don't use the dynamic loader everytime we
+        # need to reference it.
+        lddbuf=$(ldd -- "$file" 2>/dev/null)
+
         case $elf_cmd in
             *readelf)
                 "$elf_cmd" -d "$file"
             ;;
 
             *)
-                ldd -- "$file"
+                printf '%s\n' "$lddbuf"
             ;;
         esac 2>/dev/null |
 
@@ -467,6 +481,12 @@ pkg_fix_deps() {
                     # readelf: 0x0000 (NEEDED) Shared library: [libjson-c.so.5]
                     line=${line##*\[}
                     line=${line%%\]*}
+
+                    # Retrieve the fullpath of the library from our ldd buffer.
+                    case $elf_cmd in
+                        *readelf) line=$(printf '%s\n' "$lddbuf" |
+                                         pkg_fix_deps_fullpath "$line")
+                    esac
 
                     # ldd:     libjson-c.so.5 => /lib/libjson-c.so.5 ...
                     line=${line##*=> }

--- a/kiss
+++ b/kiss
@@ -1565,7 +1565,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.3.0\n' ;;
+        v|version)  printf '5.3.1\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'

--- a/kiss
+++ b/kiss
@@ -584,6 +584,8 @@ pkg_build() {
 
     log "Resolving dependencies"
 
+    nexplicit="$#"
+
     # Mark packages passed on the command-line separately from those
     # detected as dependencies. We need to treat explicitly passed packages
     # differently from those pulled in as dependencies.
@@ -615,8 +617,8 @@ pkg_build() {
 
     log "Building: $*"
 
-    # Only ask for confirmation if more than one package needs to be built.
-    [ "$#" -gt 1 ] || [ "$pkg_update" ] && prompt
+    # Only ask for confirmation if dependencies need to be built.
+    [ "$#" -ne "$nexplicit" ] || [ "$pkg_update" ] && prompt
 
     for pkg do pkg_lint "$pkg"; done
 

--- a/kiss
+++ b/kiss
@@ -637,10 +637,14 @@ pkg_build() {
     for pkg do pkg_sources "$pkg"; done
     pkg_verify "$@"
 
+    # Record the total number of packages under a variable so that they are
+    # accessible to hooks.
+    pkg_total=$#
+
     # Finally build and create tarballs for all passed packages and
     # dependencies.
     for pkg do
-        log "$pkg" "Building package ($((in+=1))/$#)"
+        log "$pkg" "Building package ($((pkg_cur+=1))/$pkg_total)"
 
         run_hook pre-extract "$pkg" "$pkg_dir/$pkg"
         pkg_extract "$pkg"

--- a/kiss
+++ b/kiss
@@ -37,17 +37,8 @@ as_root() {
     [ "$uid" = 0 ] || log "Using '${su:=su}' (to become ${user:=root})"
 
     case ${su##*/} in
-        doas|sudo|ssu)
-            "$su" -u "$user" -- env "$@"
-        ;;
-
-        su)
-            "$su" -c "env $* <&3" "$user" 3<&0 </dev/tty
-        ;;
-
-        *)
-            die "Invalid KISS_SU value: ${su##*/} (valid: doas, sudo, ssu, su)"
-        ;;
+        su) "$su" -c "env $* <&3" "$user" 3<&0 </dev/tty ;;
+        *) "$su" -u "$user" -- env "$@" ;;
     esac
 }
 

--- a/kiss
+++ b/kiss
@@ -465,8 +465,8 @@ pkg_fix_deps() {
             case $line in
                 *NEEDED*\[*\] | *'=>'*)
                     # readelf: 0x0000 (NEEDED) Shared library: [libjson-c.so.5]
-                    line=${line##*[}
-                    line=${line%%]*}
+                    line=${line##*\[}
+                    line=${line%%\]*}
 
                     # ldd:     libjson-c.so.5 => /lib/libjson-c.so.5 ...
                     line=${line##*=> }

--- a/kiss
+++ b/kiss
@@ -1304,7 +1304,7 @@ pkg_updates() {
     for repo do
         # Go to the root of the repository (if it exists).
         if ! cd "$repo" 2>/dev/null; then
-            log "Skipping "$repo", not a directory"; continue
+            log "Skipping $repo, not a directory"; continue
         fi
 
         case $(git remote 2>/dev/null) in

--- a/kiss
+++ b/kiss
@@ -2,7 +2,7 @@
 # shellcheck source=/dev/null
 #
 # This is a simple package manager written in POSIX shell for use
-# in KISS Linux (https://k1ss.org).
+# in KISS Linux (https://k1sslinux.org).
 #
 # Created by Dylan Araps.
 

--- a/kiss
+++ b/kiss
@@ -1123,7 +1123,7 @@ pkg_remove() {
     [ "$KISS_FORCE" = 1 ] || {
         log "$1" "Checking for reverse dependencies"
 
-        (cd "$sys_db"; set +f; grep -lFx "$1" -- */depends) &&
+        (cd "$sys_db"; set +f; grep -lFx -- "$1" */depends) &&
             die "$1" "Can't remove package, others depend on it"
     }
 

--- a/kiss
+++ b/kiss
@@ -37,7 +37,7 @@ as_root() {
     [ "$uid" = 0 ] || log "Using '${su:=su}' (to become ${user:=root})"
 
     case ${su##*/} in
-        doas|sudo|sls)
+        doas|sudo|ssu)
             "$su" -u "$user" -- env "$@"
         ;;
 
@@ -46,7 +46,7 @@ as_root() {
         ;;
 
         *)
-            die "Invalid KISS_SU value: $su (valid: doas, sudo, sls, su)"
+            die "Invalid KISS_SU value: ${su##*/} (valid: doas, sudo, ssu, su)"
         ;;
     esac
 }
@@ -1360,7 +1360,7 @@ pkg_updates() {
                             # on the other hand requires that each argument be
                             # properly quoted as the command passed to it must
                             # be a string... This sets quotes where needed.
-                            case $su in *su) git_cmd="'$git_cmd'"; esac
+                            case ${su##*/} in su) git_cmd="'$git_cmd'"; esac
 
                             # Spawn a subshell to run multiple commands as
                             # root at once. This makes things easier on users
@@ -1635,7 +1635,7 @@ main() {
 
     # Figure out which 'sudo' command to use based on the user's choice or what
     # is available on the system.
-    su=${KISS_SU:-"$(command -v sudo || command -v doas || command -v sls)"} ||:
+    su=${KISS_SU:-"$(command -v sudo || command -v doas || command -v ssu)"} ||:
 
     # Figure out which utility is available to dump elf information.
     elf_cmd=${KISS_ELF:="$(

--- a/kiss
+++ b/kiss
@@ -1637,7 +1637,7 @@ main() {
 
     # Figure out which 'sudo' command to use based on the user's choice or what
     # is available on the system.
-    su=${KISS_SU:-"$(command -v sudo || command -v doas || command -v ssu)"} ||:
+    su=${KISS_SU:-"$(command -v sudo || command -v doas || command -v ssu)"} || su=su
 
     # Figure out which utility is available to dump elf information.
     elf_cmd=${KISS_ELF:="$(

--- a/kiss
+++ b/kiss
@@ -625,7 +625,7 @@ pkg_build() {
     log "Building: $*"
 
     # Only ask for confirmation if more than one package needs to be built.
-    [ "$#" -gt 1 ] || [ "$pkg_update" ] && prompt
+    [ "$#" -gt 1 ] || [ "$pkg_update" ] && { prompt || exit 0 ;}
 
     for pkg do pkg_lint "$pkg"; done
 
@@ -1400,7 +1400,7 @@ pkg_updates() {
         log "Detected package manager update"
         log "The package manager will be updated first"
 
-        prompt
+        prompt || exit 0
 
         pkg_build kiss
         args i kiss

--- a/kiss
+++ b/kiss
@@ -1374,11 +1374,6 @@ pkg_updates() {
                 }
             ;;
         esac
-
-        [ ! -x update ] || {
-            log "$PWD" "Running update hook"
-            ./update
-        }
     done
 
     log "Checking for new package versions"

--- a/kiss
+++ b/kiss
@@ -1304,7 +1304,9 @@ pkg_updates() {
     # Update each repository in '$KISS_PATH'.
     for repo do
         # Go to the root of the repository (if it exists).
-        cd "$repo"
+        if ! cd "$repo" 2>/dev/null; then
+            log "Skipping "$repo", not a directory"; continue
+        fi
 
         case $(git remote 2>/dev/null) in
             "")

--- a/kiss
+++ b/kiss
@@ -1616,7 +1616,7 @@ main() {
 
     # Allow the user to disable colors in output via an environment variable.
     # Check this once so as to not slow down printing.
-    [ "$KISS_COLOR" = 0 ] || lcol='\033[1;33m' lcol2='\033[1;34m' lclr='\033[m'
+    [ "$KISS_COLOR" = 0 ] || ! [ -t 1 ] || lcol='\033[1;33m' lcol2='\033[1;34m' lclr='\033[m'
 
     # Store the original working directory to ensure that relative paths
     # passed by the user on the command-line properly resolve to locations

--- a/kiss
+++ b/kiss
@@ -1547,7 +1547,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.2.3\n' ;;
+        v|version)  printf '5.2.4\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'

--- a/kiss
+++ b/kiss
@@ -868,7 +868,7 @@ pkg_conflicts() {
     # Store the list of found conflicts in a file as we'll be using the
     # information multiple times. Storing things in the cache dir allows
     # us to be lazy as they'll be automatically removed on script end.
-    grep -Fxf "$mak_dir/$pid-m" -- "$@" 2>/dev/null > "$mak_dir/$pid-c" ||:
+    sed '/\/$/d' "$@" | sort "$mak_dir/$pid-m" - | uniq -d > "$mak_dir/$pid-c" ||:
 
     # Enable alternatives automatically if it is safe to do so.
     # This checks to see that the package that is about to be installed
@@ -899,7 +899,7 @@ pkg_conflicts() {
         # this work.
         #
         # Pretty nifty huh?
-        while IFS=: read -r _ con; do
+        while read -r con; do
             printf '%s\n' "Found conflict $con"
 
             # Create the "choices" directory inside of the tarball.

--- a/kiss
+++ b/kiss
@@ -1043,21 +1043,28 @@ pkg_remove_files() {
             }
         esac 2>/dev/null ||:
 
-        file=$KISS_ROOT/$file
+        _file=$KISS_ROOT${file%%/}
 
-        # Remove files.
-        if [ -f "$file" ] && [ ! -h "$file" ]; then
-            rm -f "$file"
+        # Queue all directory symlinks for later removal.
+        if [ -h "$_file" ] && [ -d "$_file" ]; then
+            case $file in /*/*/)
+                set -- "$@" "$_file"
+            esac
 
-        # Remove file symlinks.
-        elif [ -h "$file" ] && [ ! -d "$file" ]; then
-            rm -f "$file"
+        # Remove empty directories.
+        elif [ -d "$_file" ]; then
+            rmdir "$_file" 2>/dev/null ||:
 
-        # Remove directories if empty.
-        elif [ -d "$file" ] && [ ! -h "$file" ]; then
-            rmdir "$file" 2>/dev/null ||:
+        # Remove everything else.
+        else
+            rm -f "$_file"
         fi
     done ||:
+
+    # Remove all broken directory symlinks.
+    for sym do
+        [ -e "$sym" ] || rm -f "$sym"
+    done
 }
 
 pkg_etc() (

--- a/kiss
+++ b/kiss
@@ -736,11 +736,7 @@ pkg_build() {
     # shellcheck disable=2046,2086
     set -- $explicit
 
-    if [ "$pkg_update" ]; then
-        return
-    else
-        prompt "Install built packages? [$*]" && args i "$@"
-    fi
+    [ "$pkg_update" ] || prompt "Install built packages? [$*]" && args i "$@"
 }
 
 pkg_checksums() {

--- a/kiss
+++ b/kiss
@@ -986,11 +986,11 @@ pkg_install_files() {
     # going down the tree.
     sort "$2/$pkg_db/${2##*/}/manifest" |
 
-    while read -r line; do
+    while read -r file; do
         # Grab the octal permissions so that directory creation
         # preserves permissions.
         # See: [2] at top of script.
-        rwx=$(ls -ld "$2/$line") oct='' b='' o=0
+        rwx=$(ls -ld "$2/${file#/}") oct='' b='' o=0
 
         # Convert the output of 'ls' (rwxrwx---) to octal. This is simply
         # a 1-9 loop with the second digit being the value of the field.
@@ -1006,28 +1006,29 @@ pkg_install_files() {
             [ "$((${c%?} % 3))" = 0 ] && oct=$oct$o o=0
         done
 
+        _file=$KISS_ROOT/${file#/}
+
         # Copy files and create directories (preserving permissions),
         # skipping anything located in /etc/.
         #
         # The 'test' will run with '-e' for no-overwrite and '-z'
         # for overwrite.
-        case $line in /etc/*) ;;
+        case $file in /etc/*) ;;
             */)
                 # Skip directories if they already exist in the file system.
                 # (Think /usr/bin, /usr/lib, etc).
-                [ -d "$KISS_ROOT/$line" ] || mkdir -m "$oct" "$KISS_ROOT/$line"
+                [ -d "$_file" ] || mkdir -m "$oct" "$_file"
             ;;
 
             *)
                 # Skip directories as they're likely symlinks in this case.
                 # Pure directories in manifests have a suffix of '/'.
-                [ -d "$KISS_ROOT/$line" ] || test "$1" "$KISS_ROOT/$line" || {
-                    cp -fP "$2/$line" "$KISS_ROOT/$line"
+                [ -d "$_file" ] || test "$1" "$_file" || {
+                    cp -fP "$2/${file#/}" "$_file"
 
                     # Skip changing permissions of symlinks. This prevents
                     # errors when the symlink exists prior to the target.
-                    [ -h "$KISS_ROOT/$line" ] ||
-                        chmod "$b$oct" "$KISS_ROOT/$line"
+                    [ -h "$_file" ] || chmod "$b$oct" "$_file"
                 }
         esac
     done ||:

--- a/kiss
+++ b/kiss
@@ -597,8 +597,6 @@ pkg_build() {
 
     log "Resolving dependencies"
 
-    nexplicit="$#"
-
     # Mark packages passed on the command-line separately from those
     # detected as dependencies. We need to treat explicitly passed packages
     # differently from those pulled in as dependencies.
@@ -616,22 +614,25 @@ pkg_build() {
     # and instead install pre-built binaries if they exist.
     [ "$pkg_update" ] || explicit_build=$explicit
 
+    set --
+
     # If an explicit package is a dependency of another explicit package,
     # remove it from the explicit list as it needs to be installed as a
     # dependency.
-    for pkg do
-        contains "$deps" "$pkg" || explicit2=" $explicit2 $pkg "
+    for pkg in $explicit; do
+        contains "$deps" "$pkg" || set -- "$@" "$pkg"
     done
-    explicit=$explicit2
+    explicit_cnt=$#
+
+    log "Building: explicit: $*${deps:+, implicit: ${deps## }}"
 
     # See [1] at top of script.
     # shellcheck disable=2046,2086
-    set -- $deps $explicit
 
-    log "Building: $*"
+    set -- $deps "$@"
 
     # Only ask for confirmation if dependencies need to be built.
-    [ "$#" -ne "$nexplicit" ] || [ "$pkg_update" ] && prompt
+    [ "$#" -ne "$explicit_cnt" ] || [ "$pkg_update" ] && prompt
 
     for pkg do pkg_lint "$pkg"; done
 

--- a/kiss
+++ b/kiss
@@ -743,21 +743,15 @@ pkg_checksums() {
     # Generate checksums for packages.
     repo_dir=$(pkg_find "$1")
 
-    # Support packages without sources. Simply do nothing.
-    [ -f "$repo_dir/sources" ] || return 0
-
     while read -r src dest || [ "$src" ]; do
-        # Skip comments, blank lines and git sources.
-        if [ -z "${src##\#*}" ] || [ -z "${src##git+*}" ]; then
+        # Skip directories, comments, blank lines, and git sources.
+        if [ -z "${src##\#*}" ] || [ -z "${src##git+*}" ] ||
+           [ -d "$repo_dir/$src" ] || [ -d "/$src" ]; then
             :
 
         # Remote source.
         elif [ -z "${src##*://*}" ]; then
             sh256 "$src_dir/$1/${dest:-.}/${src##*/}"
-
-        # Skip directories.
-        elif [ -d "$repo_dir/$src" ] || [ -d "/$src" ]; then
-            :
 
         # Local file (relative).
         elif [ -f "$repo_dir/$src" ]; then

--- a/kiss
+++ b/kiss
@@ -1310,10 +1310,12 @@ pkg_updates() {
 
     # Update each repository in '$KISS_PATH'.
     for repo do
-        # Go to the root of the repository (if it exists).
-        if ! cd "$repo" 2>/dev/null; then
-            log "Skipping $repo, not a directory"; continue
-        fi
+        [ -d "$repo" ] || {
+            log "$repo" " "
+            printf 'Skipping repository, not a directory\n'
+            continue
+        }
+        cd "$repo"
 
         case $(git remote 2>/dev/null) in
             "")

--- a/kiss
+++ b/kiss
@@ -442,14 +442,6 @@ pkg_strip() {
     done 2>/dev/null ||:
 }
 
-pkg_fix_deps_fullpath() {
-    # Return the canonical path of libraries extracted by readelf.
-    while read -r dep _ rslv _; do
-        [ "$dep" = "$1" ] || continue
-        printf '%s\n' "$rslv"
-    done
-}
-
 pkg_fix_deps() {
     # Dynamically look for missing runtime dependencies by checking each
     # binary and library with 'ldd'. This catches any extra libraries and or
@@ -466,11 +458,7 @@ pkg_fix_deps() {
     find "$pkg_dir/${PWD##*/}/" -type f 2>/dev/null |
 
     while read -r file; do
-        # We call ldd regardless here, because we also use it to retrieve the
-        # fullpath of a library when using readelf. Best use we have here is
-        # saving it in a buffer, so we don't use the dynamic loader everytime we
-        # need to reference it.
-        lddbuf=$(ldd -- "$file" 2>/dev/null) ||:
+        ldd_buf=$(ldd -- "$file" 2>/dev/null) ||:
 
         case $elf_cmd in
             *readelf)
@@ -478,7 +466,7 @@ pkg_fix_deps() {
             ;;
 
             *)
-                printf '%s\n' "$lddbuf"
+                printf '%s\n' "$ldd_buf"
             ;;
         esac 2>/dev/null |
 
@@ -489,14 +477,12 @@ pkg_fix_deps() {
                     line=${line##*\[}
                     line=${line%%\]*}
 
-                    # Retrieve the fullpath of the library from our ldd buffer.
+                    # Resolve library path.
+                    # ldd: libjson-c.so.5 => /lib/libjson-c.so.5 ...
                     case $elf_cmd in
-                        *readelf) line=$(printf '%s\n' "$lddbuf" |
-                                         pkg_fix_deps_fullpath "$line")
+                        *readelf) line=${ldd_buf#*"	$line => "} ;;
+                        *)        line=${line##*=> } ;;
                     esac
-
-                    # ldd:     libjson-c.so.5 => /lib/libjson-c.so.5 ...
-                    line=${line##*=> }
                     line=${line%% *}
 
                     # Skip files owned by libc and POSIX.
@@ -752,7 +738,7 @@ pkg_build() {
 
     if [ "$pkg_update" ]; then
         return
-    else 
+    else
         prompt "Install built packages? [$*]" && args i "$@"
     fi
 }

--- a/kiss
+++ b/kiss
@@ -219,10 +219,17 @@ pkg_sources() {
             log "$1" "Downloading $src"
             mkdir -p "$PWD/$dest"
 
+            # We don't want interrupt to exit immediately here, so we change the
+            # behaviour here.
+            trap pkg_clean INT
+
             curl "$src" -fLo "./${dest:-.}/${src##*/}" || {
                 rm -f "./${dest:-.}/${src##*/}"
                 die "$1" "Failed to download $src"
             }
+
+            # Restore the trap to the original value.
+            trap 'pkg_clean; exit 1' INT
 
         # Local source (relative).
         elif [ -e "$repo_dir/$src" ]; then

--- a/kiss
+++ b/kiss
@@ -1572,7 +1572,7 @@ args() {
         l|list)     pkg_list "$@" ;;
         u|update)   pkg_updates ;;
         s|search)   for pkg do pkg_find "$pkg" all; done ;;
-        v|version)  printf '5.3.1\n' ;;
+        v|version)  printf '5.3.2\n' ;;
 
         '')
             log 'kiss [a|b|c|d|i|l|r|s|u|v] [pkg]...'

--- a/kiss
+++ b/kiss
@@ -270,7 +270,7 @@ pkg_extract() {
                 log "$1" "Cloning ${url%[#@]*}"; {
                     git init
                     git remote add origin "${url%[#@]*}"
-                    git fetch -t --depth 1 origin "$com" || git fetch -t
+                    git fetch -t --filter=tree:0 origin "$com" || git fetch -t
                     git -c advice.detachedHead=0 checkout "${com:-FETCH_HEAD}"
                 } || die "$1" "Failed to clone $src"
             ;;

--- a/kiss
+++ b/kiss
@@ -1415,9 +1415,15 @@ pkg_updates() {
         args i kiss
 
         log "Updated the package manager"
-        log "Re-run 'kiss update' to update your system"
+        log "Re-running 'kiss update' to update your system"
 
-        exit 0
+        if ! BIN=$(command -v kiss); then
+            die "Could not find kiss in PATH"
+        fi
+
+        prompt
+
+        exec "$BIN" update
     }
 
     [ "$1" ] || {

--- a/kiss
+++ b/kiss
@@ -1619,6 +1619,39 @@ args() {
     fi
 }
 
+create_tmp_dirs() {
+    # Root directory.
+    KISS_ROOT=${KISS_ROOT%"${KISS_ROOT##*[!/]}"}
+
+    # This allows for automatic setup of a KISS chroot and will
+    # do nothing on a normal system.
+    mkdir -p "$KISS_ROOT/" 2>/dev/null ||:
+
+    # System package database.
+    sys_db=$KISS_ROOT/${pkg_db:=var/db/kiss/installed}
+
+    # Top-level cache directory.
+    cac_dir=${XDG_CACHE_HOME:-"${HOME%"${HOME##*[!/]}"}/.cache"}
+    cac_dir=${cac_dir%"${cac_dir##*[!/]}"}/kiss
+
+    # Persistent cache directories.
+    src_dir=$cac_dir/sources
+    log_dir=$cac_dir/logs/${time%-*}
+    bin_dir=$cac_dir/bin
+
+    # Top-level Temporary cache directory.
+    tmp_dir=${KISS_TMPDIR:="$cac_dir/proc"}
+    tmp_dir=${tmp_dir%"${tmp_dir##*[!/]}"}/kiss/$pid
+
+    # Temporary cache directories.
+    mak_dir=$tmp_dir/build
+    pkg_dir=$tmp_dir/pkg
+    tar_dir=$tmp_dir/extract
+
+    mkdir -p "$src_dir" "$log_dir" "$bin_dir" \
+             "$mak_dir" "$pkg_dir" "$tar_dir"
+}
+
 main() {
     # Globally disable globbing and enable exit-on-error.
     set -ef
@@ -1662,28 +1695,7 @@ main() {
     # This is used enough to warrant a place here.
     uid=$(id -u)
 
-    # Ensure that the KISS_ROOT doesn't end with a '/'.
-    KISS_ROOT=${KISS_ROOT%"${KISS_ROOT##*[!/]}"}
-
-    # Define some paths which we will then use throughout the script.
-    sys_db=$KISS_ROOT/${pkg_db:=var/db/kiss/installed}
-
-    # This allows for automatic setup of a KISS chroot and will
-    # do nothing on a normal system.
-    mkdir -p "$KISS_ROOT/" 2>/dev/null ||:
-
-    # Create the required temporary directories and set the variables which
-    # point to them.
-    mkdir -p \
-        "${cac_dir:="${XDG_CACHE_HOME:-"${HOME:?HOME is null}/.cache"}/kiss"}" \
-            "${src_dir:="$cac_dir/sources"}" \
-            "${log_dir:="$cac_dir/logs/${date%-*}"}" \
-            "${bin_dir:="$cac_dir/bin"}" \
-        "${tmp_dir:="${KISS_TMPDIR:="$cac_dir/proc"}/$pid"}" \
-            "${mak_dir:="$tmp_dir/build"}" \
-            "${pkg_dir:="$tmp_dir/pkg"}" \
-            "${tar_dir:="$tmp_dir/extract"}"
-
+    create_tmp_dirs
     args "$@"
 }
 

--- a/test/tests.d/02-kiss-update-kiss.sh
+++ b/test/tests.d/02-kiss-update-kiss.sh
@@ -1,0 +1,13 @@
+#!/bin/sh -e
+
+kiss new kiss 1
+kiss new foo 1
+
+kiss b kiss foo
+kiss i kiss foo
+
+sed -i "s/1/2/" ./*/version
+
+kiss u
+kiss list kiss | grep 2
+kiss list foo | grep 2


### PR DESCRIPTION
Continue the upgrade even if kiss itself is upgrade instead of aborting
early. This is achieved by exec-ing into the freshly installed kiss.

The goal of this is to allow `kiss u` to be run as a script and to
always succeed in updating packages given the packages can actually be
accessed and built.