### PR TITLE
Make aria2 use the absolute path

### DIFF
--- a/kiss
+++ b/kiss
@@ -431,9 +431,10 @@ pkg_source_url() {
 
     # Set the arguments based on found download utility.
     case ${cmd_get##*/} in
-        aria2c|axel) set -- -o   "$@" ;;
-               curl) set -- -fLo "$@" ;;
-         wget|wget2) set -- -O   "$@" ;;
+            aria2c) set -- -d / -o  "$@" ;;
+              axel) set -- -o       "$@" ;;
+              curl) set -- -fLo     "$@" ;;
+        wget|wget2) set -- -O       "$@" ;;
     esac
 
     "$cmd_get" "$@" || {


### PR DESCRIPTION
aria2 uses a relative path for the `-o` option. So added the `-d /` option to make aria2 use an absolute path.