### PR TITLE
kiss-preferred: big speed increase by using parallel xargs

### DIFF
--- a/contrib/kiss-preferred
+++ b/contrib/kiss-preferred
@@ -1,12 +1,8 @@
 #!/bin/sh -e
 # Lists the owners of all files with conflicts
 
-kiss a | while read -r _ path; do
-    if owner=$(kiss owns "$path" 2>/dev/null) && [ "$owner" ]; then
-        printf '%s %s\n' "$owner" "$path"
-
-    else
-        printf 'warning: %s has no owner\n' "$path" >&2
-    fi
-done
-
+kiss alternatives \
+    | cut -d' ' -f2 \
+    | xargs -P0 -I{} \
+    sh -c "( kiss owns {}; echo {} ) | paste - -" \
+    tr '\t' ' '


### PR DESCRIPTION
Instead of looping over every package sequentially, make use of
xargs and parallelize the output. Output is almost identical to the
current utility, however it does not list out files that have no
owner.

Timings (on my system, avg of 3):

kiss-preferred (old) - 5.03s
kiss-preferred (new) - 0.55s