### PR TITLE
kiss-sync: new utility to just sync repositories

### DIFF
--- a/kiss
+++ b/kiss
@@ -1596,7 +1596,7 @@ pkg_update() {
         pkg_update_repo
     done
 
-    pkg_upgrade
+    log "Run 'kiss U' to upgrade packages"
 }
 
 pkg_update_repo() {


### PR DESCRIPTION
This allows for the syncing of repositories that are in KISS_PATH
without prompting the user for a 'Control+C' to cancel the upgrade.