### PR TITLE
kiss-(rev)depends: also search outside locally installed

### DIFF
--- a/contrib/kiss-depends
+++ b/contrib/kiss-depends
@@ -3,11 +3,14 @@
 
 pkg=${1:-"${PWD##*/}"}
 
-kiss list "$pkg" >/dev/null || {
+kiss search "$pkg" >/dev/null || {
     printf 'usage: kiss-depends [pkg]\n' >&2
     exit 1
 }
 
-while read -r dep mak || [ "$dep" ]; do
-    printf '%s%s\n' "$dep" "${mak:+ "$mak"}"
-done 2>/dev/null < "$KISS_ROOT/var/db/kiss/installed/$pkg/depends" 
+kiss search "$pkg" | while read -r pkgpath; do
+    printf '=> %s\n' "$pkgpath"
+    while read -r dep mak || [ "$dep" ]; do
+        printf '%s%s\n' "$dep" "${mak:+ "$mak"}"
+    done 2>/dev/null < "$KISS_ROOT/$pkgpath/depends"
+done

--- a/contrib/kiss-revdepends
+++ b/contrib/kiss-revdepends
@@ -3,7 +3,5 @@
 
 [ "$1" ] || set -- "${PWD##*/}"
 
-cd "$KISS_ROOT/var/db/kiss/installed"
-
-grep -E "^$1( |$)"  -- */depends
-
+# shellcheck ignore=SC2046
+grep -E "^$1( |$)"  -- $(kiss search \* | sed 's/$/\/depends/') 2>/dev/null


### PR DESCRIPTION
allow for both `kiss-depends` and `kiss-revdepends` to search outside of locally installed packages.

i am unsure weather `sed 's/$/\/depends/'` is POSIX Compliant or not.